### PR TITLE
Bouncycastle 1.58

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <properties>
         <net.ripe.ipresource.version>1.46</net.ripe.ipresource.version>
-        <bouncycastle.version>1.49</bouncycastle.version>
+        <bouncycastle.version>1.58</bouncycastle.version>
         <joda-time.version>2.3</joda-time.version>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
         <sonar.clover.reportPath>target/site/clover/clover.xml</sonar.clover.reportPath>

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObject.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObject.java
@@ -50,16 +50,20 @@ public abstract class RpkiSignedObject implements CertificateRepositoryObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String RSA_ENCRYPTION_OID = CMSSignedDataGenerator.ENCRYPTION_RSA;
-
-    // The "sha256WithRsa" Object Id is defined in RFC6485 but no existing implementations, at least bouncy castle and
-    // openssl support this. There is a plan to issue an erratum for RFC6485 to just go with plain "rsa" as existing
-    // implementations are doing. Until that time, we had better accept both when doing validation.
+    /**
+     * CMS signed objects must indicate signing algorithm as "sha256WithRsa".
+     */
     public static final String SHA256WITHRSA_ENCRYPTION_OID = PKCSObjectIdentifiers.sha256WithRSAEncryption.getId();
 
+    /**
+     * However, older versions of BouncyCastle did not support this OID and use "rsaEncryption" instead.
+     * We accept both when parsing and validating, but sign with "sha256WithRsa" now.
+     */
+    public static final String RSA_ENCRYPTION_OID = CMSSignedDataGenerator.ENCRYPTION_RSA;
+
     public static final List<String> ALLOWED_SIGNATURE_ALGORITHM_OIDS = Arrays.asList(
-        PKCSObjectIdentifiers.sha256WithRSAEncryption.getId(),
-        PKCSObjectIdentifiers.rsaEncryption.getId()
+        SHA256WITHRSA_ENCRYPTION_OID,
+        RSA_ENCRYPTION_OID
     );
 
     /**

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObject.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObject.java
@@ -57,6 +57,11 @@ public abstract class RpkiSignedObject implements CertificateRepositoryObject {
     // implementations are doing. Until that time, we had better accept both when doing validation.
     public static final String SHA256WITHRSA_ENCRYPTION_OID = PKCSObjectIdentifiers.sha256WithRSAEncryption.getId();
 
+    public static final List<String> ALLOWED_SIGNATURE_ALGORITHM_OIDS = Arrays.asList(
+        PKCSObjectIdentifiers.sha256WithRSAEncryption.getId(),
+        PKCSObjectIdentifiers.rsaEncryption.getId()
+    );
+
     /**
      * The digestAlgorithms set MUST include only SHA-256, the OID for which is
      * 2.16.840.1.101.3.4.2.1. [RFC4055] It MUST NOT contain any other

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectParser.java
@@ -276,7 +276,7 @@ public abstract class RpkiSignedObjectParser {
 
     private boolean verifySigner(SignerInformation signer, X509Certificate certificate) {
         validationResult.rejectIfFalse(DIGEST_ALGORITHM_OID.equals(signer.getDigestAlgOID()), CMS_SIGNER_INFO_DIGEST_ALGORITHM);
-        validationResult.rejectIfFalse(RSA_ENCRYPTION_OID.equals(signer.getEncryptionAlgOID()) || SHA256WITHRSA_ENCRYPTION_OID.equals(signer.getEncryptionAlgOID()), ENCRYPTION_ALGORITHM);
+        validationResult.rejectIfFalse(ALLOWED_SIGNATURE_ALGORITHM_OIDS.contains(signer.getEncryptionAlgOID()), ENCRYPTION_ALGORITHM);
         if (!validationResult.rejectIfNull(signer.getSignedAttributes(), SIGNED_ATTRS_PRESENT)) {
             return false;
         }

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509Crl.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509Crl.java
@@ -39,7 +39,7 @@ import net.ripe.rpki.commons.validation.ValidationString;
 import net.ripe.rpki.commons.validation.objectvalidators.CertificateRepositoryObjectValidationContext;
 import org.apache.commons.lang.Validate;
 import org.bouncycastle.asn1.ASN1Integer;
-import org.bouncycastle.asn1.x509.X509Extension;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.x509.extension.X509ExtensionUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -236,7 +236,7 @@ public class X509Crl implements CertificateRepositoryObject {
 
     public BigInteger getNumber() {
         try {
-            byte[] extensionValue = getCrl().getExtensionValue(X509Extension.cRLNumber.getId());
+            byte[] extensionValue = getCrl().getExtensionValue(Extension.cRLNumber.getId());
             if (extensionValue == null) {
                 return null;
             }

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilder.java
@@ -36,7 +36,7 @@ import org.apache.commons.lang.Validate;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
 import org.bouncycastle.asn1.x509.CRLNumber;
-import org.bouncycastle.asn1.x509.X509Extension;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509v2CRLBuilder;
 import org.bouncycastle.operator.ContentSigner;
@@ -144,8 +144,8 @@ public class X509CrlBuilder {
     private X509v2CRLBuilder createCrlGenerator() throws CertIOException {
         X509v2CRLBuilder generator = new X509v2CRLBuilder(X500Name.getInstance(issuerDN.getEncoded()), thisUpdateTime.toDate());
         generator.setNextUpdate(nextUpdateTime.toDate());
-        generator.addExtension(X509Extension.authorityKeyIdentifier, false, authorityKeyIdentifier);
-        generator.addExtension(X509Extension.cRLNumber, false, crlNumber);
+        generator.addExtension(Extension.authorityKeyIdentifier, false, authorityKeyIdentifier);
+        generator.addExtension(Extension.cRLNumber, false, crlNumber);
         for (X509Crl.Entry entry : entries.values()) {
             generator.addCRLEntry(entry.getSerialNumber(), entry.getRevocationDateTime().toDate(), 0);
         }

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
@@ -43,11 +43,11 @@ import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.DistributionPoint;
 import org.bouncycastle.asn1.x509.DistributionPointName;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.PolicyInformation;
-import org.bouncycastle.asn1.x509.X509Extension;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
@@ -311,41 +311,41 @@ public final class X509CertificateBuilderHelper {
     }
 
     private void addSubjectKeyIdentifier(X509v3CertificateBuilder generator) throws InvalidKeyException, CertIOException, NoSuchAlgorithmException {
-        generator.addExtension(X509Extension.subjectKeyIdentifier, false, new JcaX509ExtensionUtils().createSubjectKeyIdentifier(publicKey));
+        generator.addExtension(Extension.subjectKeyIdentifier, false, new JcaX509ExtensionUtils().createSubjectKeyIdentifier(publicKey));
     }
 
     private void addAuthorityKeyIdentifier(X509v3CertificateBuilder generator) throws InvalidKeyException, CertIOException {
         generator.addExtension(
-                X509Extension.authorityKeyIdentifier,
+                Extension.authorityKeyIdentifier,
                 false,
                 BouncyCastleUtil.createAuthorityKeyIdentifier(signingKeyPair.getPublic()));
     }
 
     private void addCaBit(X509v3CertificateBuilder generator) throws CertIOException {
-        generator.addExtension(X509Extension.basicConstraints, true, new BasicConstraints(ca));
+        generator.addExtension(Extension.basicConstraints, true, new BasicConstraints(ca));
     }
 
     private void addKeyUsage(X509v3CertificateBuilder generator) throws CertIOException {
-        generator.addExtension(X509Extension.keyUsage, true, new KeyUsage(keyUsage));
+        generator.addExtension(Extension.keyUsage, true, new KeyUsage(keyUsage));
     }
 
     private void addAIA(X509v3CertificateBuilder generator) throws CertIOException {
-        generator.addExtension(X509Extension.authorityInfoAccess, false,
+        generator.addExtension(Extension.authorityInfoAccess, false,
                 AuthorityInformationAccess.getInstance(new DERSequence(authorityInformationAccess)));
     }
 
     private void addSIA(X509v3CertificateBuilder generator) throws CertIOException {
-        generator.addExtension(X509Extension.subjectInfoAccess, false,
+        generator.addExtension(Extension.subjectInfoAccess, false,
                 AuthorityInformationAccess.getInstance(new DERSequence(subjectInformationAccess)));
     }
 
     private void addCrlDistributionPoints(X509v3CertificateBuilder generator) throws CertIOException {
         CRLDistPoint crldp = convertToCrlDistributionPoint(crlDistributionPoints);
-        generator.addExtension(X509Extension.cRLDistributionPoints, false, crldp);
+        generator.addExtension(Extension.cRLDistributionPoints, false, crldp);
     }
 
     private void addPolicies(X509v3CertificateBuilder generator) throws CertIOException {
-        generator.addExtension(X509Extension.certificatePolicies, true, new DERSequence(policies));
+        generator.addExtension(Extension.certificatePolicies, true, new DERSequence(policies));
     }
 
     private void addResourceExtensions(X509v3CertificateBuilder generator) throws CertIOException {

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
@@ -46,7 +46,7 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.asn1.x509.TBSCertificateStructure;
+import org.bouncycastle.asn1.x509.TBSCertificate;
 import org.bouncycastle.util.encoders.Base64Encoder;
 import org.bouncycastle.x509.extension.X509ExtensionUtil;
 
@@ -121,7 +121,7 @@ public final class X509CertificateUtil {
             throw new X509CertificateOperationException("Can't extract TBSCertificate from certificate", e);
         }
         ASN1Sequence tbsCertificateSequence = (ASN1Sequence) Asn1Util.decode(tbsCertificate);
-        TBSCertificateStructure tbsCertificateStructure = new TBSCertificateStructure(tbsCertificateSequence);
+        TBSCertificate tbsCertificateStructure = TBSCertificate.getInstance(tbsCertificateSequence);
         SubjectPublicKeyInfo subjectPublicKeyInfo = tbsCertificateStructure.getSubjectPublicKeyInfo();
 
         try {

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
@@ -77,7 +77,7 @@ public final class X509CertificateUtil {
 
     public static byte[] getSubjectKeyIdentifier(X509Extension certificate) {
         try {
-            byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.X509Extension.subjectKeyIdentifier.getId());
+            byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.Extension.subjectKeyIdentifier.getId());
             if (extensionValue == null) {
                 return null;
             }
@@ -89,7 +89,7 @@ public final class X509CertificateUtil {
 
     public static byte[] getAuthorityKeyIdentifier(X509Extension certificate) {
         try {
-            byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.X509Extension.authorityKeyIdentifier.getId());
+            byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.Extension.authorityKeyIdentifier.getId());
             if (extensionValue == null) {
                 return null;
             }
@@ -142,7 +142,7 @@ public final class X509CertificateUtil {
 
     public static boolean isCa(X509Certificate certificate) {
         try {
-            byte[] basicConstraintsExtension = certificate.getExtensionValue(org.bouncycastle.asn1.x509.X509Extension.basicConstraints.getId());
+            byte[] basicConstraintsExtension = certificate.getExtensionValue(org.bouncycastle.asn1.x509.Extension.basicConstraints.getId());
             if (basicConstraintsExtension == null) {
                 /**
                  * The Basic Constraints extension field [...] MUST be present when
@@ -164,7 +164,7 @@ public final class X509CertificateUtil {
 
     public static X509CertificateInformationAccessDescriptor[] getAuthorityInformationAccess(X509Certificate certificate) {
         try {
-            byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.X509Extension.authorityInfoAccess.getId());
+            byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.Extension.authorityInfoAccess.getId());
             if (extensionValue == null) {
                 return null;
             }
@@ -177,7 +177,7 @@ public final class X509CertificateUtil {
 
     public static X509CertificateInformationAccessDescriptor[] getSubjectInformationAccess(X509Certificate certificate) {
         try {
-            byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.X509Extension.subjectInfoAccess.getId());
+            byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.Extension.subjectInfoAccess.getId());
             if (extensionValue == null) {
                 return null;
             }
@@ -211,7 +211,7 @@ public final class X509CertificateUtil {
     }
 
     public static URI[] getCrlDistributionPoints(X509Certificate certificate) {
-        byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.X509Extension.cRLDistributionPoints.getId());
+        byte[] extensionValue = certificate.getExtensionValue(org.bouncycastle.asn1.x509.Extension.cRLDistributionPoints.getId());
         if (extensionValue == null) {
             return null;
         }

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -37,13 +37,7 @@ import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
-import org.bouncycastle.asn1.x509.CRLDistPoint;
-import org.bouncycastle.asn1.x509.DistributionPoint;
-import org.bouncycastle.asn1.x509.DistributionPointName;
-import org.bouncycastle.asn1.x509.GeneralName;
-import org.bouncycastle.asn1.x509.GeneralNames;
-import org.bouncycastle.asn1.x509.PolicyInformation;
-import org.bouncycastle.asn1.x509.X509Extension;
+import org.bouncycastle.asn1.x509.*;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.x509.extension.X509ExtensionUtil;
 
@@ -151,7 +145,7 @@ public class X509ResourceCertificateParser extends X509CertificateParser<X509Res
     }
 
     private void validateCrlDistributionPoints() {
-        byte[] extensionValue = certificate.getExtensionValue(X509Extension.cRLDistributionPoints.getId());
+        byte[] extensionValue = certificate.getExtensionValue(Extension.cRLDistributionPoints.getId());
 
         if (isRoot(certificate)) {
             // early ripe ncc ta certificates have crldp set so for now only warn here

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -116,10 +116,10 @@ public class X509ResourceCertificateParser extends X509CertificateParser<X509Res
             return;
         }
 
-        result.rejectIfFalse(certificate.getCriticalExtensionOIDs().contains(X509Extension.certificatePolicies.getId()), POLICY_EXT_CRITICAL);
+        result.rejectIfFalse(certificate.getCriticalExtensionOIDs().contains(Extension.certificatePolicies.getId()), POLICY_EXT_CRITICAL);
 
         try {
-            byte[] extensionValue = certificate.getExtensionValue(X509Extension.certificatePolicies.getId());
+            byte[] extensionValue = certificate.getExtensionValue(Extension.certificatePolicies.getId());
             if (!result.rejectIfNull(extensionValue, POLICY_EXT_VALUE)) {
                 return;
             }

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -37,7 +37,13 @@ import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
-import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.asn1.x509.CRLDistPoint;
+import org.bouncycastle.asn1.x509.DistributionPoint;
+import org.bouncycastle.asn1.x509.DistributionPointName;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.PolicyInformation;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.x509.extension.X509ExtensionUtil;
 
@@ -46,8 +52,9 @@ import java.net.URI;
 import java.security.cert.CertificateEncodingException;
 import java.util.regex.Pattern;
 
-import static net.ripe.rpki.commons.crypto.x509cert.AbstractX509CertificateWrapper.*;
-import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateUtil.*;
+import static net.ripe.rpki.commons.crypto.x509cert.AbstractX509CertificateWrapper.POLICY_OID;
+import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateUtil.findFirstRsyncCrlDistributionPoint;
+import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateUtil.isRoot;
 import static net.ripe.rpki.commons.validation.ValidationString.*;
 
 

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParser.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParser.java
@@ -50,10 +50,9 @@ import org.bouncycastle.asn1.cms.AttributeTable;
 import org.bouncycastle.asn1.cms.CMSAttributes;
 import org.bouncycastle.asn1.cms.ContentInfo;
 import org.bouncycastle.asn1.cms.SignedData;
-import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.BasicConstraints;
-import org.bouncycastle.asn1.x509.X509Extension;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.cms.CMSSignedDataParser;
 import org.bouncycastle.cms.CMSSignedGenerator;
@@ -259,7 +258,7 @@ public class ProvisioningCmsObjectParser {
 
     private boolean isEndEntityCertificate(X509Certificate certificate) {
         try {
-            byte[] basicConstraintsExtension = certificate.getExtensionValue(X509Extension.basicConstraints.getId());
+            byte[] basicConstraintsExtension = certificate.getExtensionValue(Extension.basicConstraints.getId());
             if (basicConstraintsExtension == null) {
                 /**
                  * If the basic constraints extension is not present [...] then the certified public key MUST NOT be used

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParser.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParser.java
@@ -50,6 +50,7 @@ import org.bouncycastle.asn1.cms.AttributeTable;
 import org.bouncycastle.asn1.cms.CMSAttributes;
 import org.bouncycastle.asn1.cms.ContentInfo;
 import org.bouncycastle.asn1.cms.SignedData;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.X509Extension;
@@ -81,6 +82,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
+import static net.ripe.rpki.commons.crypto.cms.RpkiSignedObject.ALLOWED_SIGNATURE_ALGORITHM_OIDS;
 import static net.ripe.rpki.commons.validation.ValidationString.*;
 
 public class ProvisioningCmsObjectParser {
@@ -426,11 +428,11 @@ public class ProvisioningCmsObjectParser {
     }
 
     /**
-     * http://tools.ietf.org/html/draft-ietf-sidr-rescerts-provisioning-09#section-3.1.1.6.5
-     * http://tools.ietf.org/html/draft-huston-sidr-rpki-algs-00#section-2
+     * https://tools.ietf.org/html/rfc6492#section-3.1.1.6.5
+     * https://tools.ietf.org/html/rfc7935#section-2
      */
     private void verifyEncryptionAlgorithm(SignerInformation signer) {
-        validationResult.rejectIfFalse(CMSSignedGenerator.ENCRYPTION_RSA.equals(signer.getEncryptionAlgOID()), ENCRYPTION_ALGORITHM);
+        validationResult.rejectIfFalse(ALLOWED_SIGNATURE_ALGORITHM_OIDS.contains(signer.getEncryptionAlgOID()), ENCRYPTION_ALGORITHM);
     }
 
     /**

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestParser.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestParser.java
@@ -39,7 +39,6 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AccessDescription;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.Extensions;
-import org.bouncycastle.asn1.x509.X509Extension;
 import org.bouncycastle.operator.ContentVerifierProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
@@ -119,7 +118,7 @@ public class RpkiCaCertificateRequestParser {
     private void extractSiaUris() throws RpkiCaCertificateRequestParserException {
         try {
             Extensions extensions = getPkcs9Extensions();
-            Extension extension = extensions.getExtension(X509Extension.subjectInfoAccess);
+            Extension extension = extensions.getExtension(Extension.subjectInfoAccess);
 
             ASN1Sequence accessDescriptorSequence = (ASN1Sequence) ASN1Sequence.fromByteArray(extension.getExtnValue().getOctets());
 

--- a/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderTest.java
@@ -35,11 +35,7 @@ import net.ripe.rpki.commons.provisioning.payload.AbstractProvisioningPayload;
 import net.ripe.rpki.commons.provisioning.payload.list.request.ResourceClassListQueryPayload;
 import net.ripe.rpki.commons.provisioning.payload.list.request.ResourceClassListQueryPayloadBuilder;
 import net.ripe.rpki.commons.provisioning.x509.ProvisioningCmsCertificateBuilderTest;
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1Set;
-import org.bouncycastle.asn1.DERUTCTime;
+import org.bouncycastle.asn1.*;
 import org.bouncycastle.asn1.cms.Attribute;
 import org.bouncycastle.asn1.cms.AttributeTable;
 import org.bouncycastle.asn1.cms.CMSAttributes;
@@ -66,6 +62,7 @@ import java.security.cert.CertStoreException;
 import java.security.cert.X509CRL;
 import java.util.Collection;
 
+import static net.ripe.rpki.commons.crypto.cms.RpkiSignedObject.SHA256WITHRSA_ENCRYPTION_OID;
 import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper.*;
 import static net.ripe.rpki.commons.provisioning.ProvisioningObjectMother.*;
 import static org.bouncycastle.cms.CMSSignedGenerator.*;
@@ -298,7 +295,7 @@ public class ProvisioningCmsObjectBuilderTest {
 
         assertNotNull(signingTimeAttr);
         assertEquals(1, signingTimeAttr.getAttrValues().size());
-        DERUTCTime signingTime = (DERUTCTime) signingTimeAttr.getAttrValues().getObjectAt(0);
+        ASN1UTCTime signingTime = (ASN1UTCTime) signingTimeAttr.getAttrValues().getObjectAt(0);
         assertEquals(this.signingTime, signingTime.getDate().getTime());
     }
 
@@ -324,7 +321,7 @@ public class ProvisioningCmsObjectBuilderTest {
         Collection<?> signers = signedDataParser.getSignerInfos().getSigners();
         SignerInformation signer = (SignerInformation) signers.iterator().next();
 
-        assertEquals(ENCRYPTION_RSA, signer.getEncryptionAlgOID());
+        assertEquals(SHA256WITHRSA_ENCRYPTION_OID, signer.getEncryptionAlgOID());
     }
 
     /**

--- a/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderTest.java
@@ -35,7 +35,11 @@ import net.ripe.rpki.commons.provisioning.payload.AbstractProvisioningPayload;
 import net.ripe.rpki.commons.provisioning.payload.list.request.ResourceClassListQueryPayload;
 import net.ripe.rpki.commons.provisioning.payload.list.request.ResourceClassListQueryPayloadBuilder;
 import net.ripe.rpki.commons.provisioning.x509.ProvisioningCmsCertificateBuilderTest;
-import org.bouncycastle.asn1.*;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Set;
+import org.bouncycastle.asn1.ASN1UTCTime;
 import org.bouncycastle.asn1.cms.Attribute;
 import org.bouncycastle.asn1.cms.AttributeTable;
 import org.bouncycastle.asn1.cms.CMSAttributes;
@@ -63,9 +67,9 @@ import java.security.cert.X509CRL;
 import java.util.Collection;
 
 import static net.ripe.rpki.commons.crypto.cms.RpkiSignedObject.SHA256WITHRSA_ENCRYPTION_OID;
-import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper.*;
-import static net.ripe.rpki.commons.provisioning.ProvisioningObjectMother.*;
-import static org.bouncycastle.cms.CMSSignedGenerator.*;
+import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper.DEFAULT_SIGNATURE_PROVIDER;
+import static net.ripe.rpki.commons.provisioning.ProvisioningObjectMother.CRL;
+import static org.bouncycastle.cms.CMSSignedGenerator.DIGEST_SHA256;
 import static org.junit.Assert.*;
 
 public class ProvisioningCmsObjectBuilderTest {


### PR DESCRIPTION
Upgrade to Bouncy Castle 1.58. Most significant change is that CMS objects are generated with the "sha256WithRsa" signing algorithm identifier, as is required by the RPKI RFCs. CMS objects signed with "rsaEncyption" are still accepted when validating.