### PR TITLE
Do not check if CRL or MFT is stale, only validate the validity of th…

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
@@ -159,11 +159,7 @@ public class ManifestCms extends RpkiSignedObject {
         DateTime nextUpdateTime = getNextUpdateTime();
 
         if (now.isAfter(nextUpdateTime)) {
-            if (nextUpdateTime.plusDays(options.getMaxStaleDays()).isAfter(now)) {
-                result.warnIfTrue(true, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME);
-            } else {
-                result.rejectIfTrue(true, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME);
-            }
+            result.warnIfTrue(true, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME);
         }
     }
 

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
@@ -157,10 +157,7 @@ public class ManifestCms extends RpkiSignedObject {
     private void checkManifestValidityTimes(ValidationOptions options, ValidationResult result) {
         DateTime now = new DateTime();
         DateTime nextUpdateTime = getNextUpdateTime();
-
-        if (now.isAfter(nextUpdateTime)) {
-            result.warnIfTrue(true, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME);
-        }
+        result.warnIfTrue(now.isAfter(nextUpdateTime), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME);
     }
 
     /**

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
@@ -148,23 +148,8 @@ public class ManifestCms extends RpkiSignedObject {
 
     protected void validateWithCrl(String location, CertificateRepositoryObjectValidationContext context, ValidationOptions options, ValidationResult result, X509Crl crl) {
         result.setLocation(new ValidationLocation(location));
-        checkManifestValidityTimes(options, result);
         X509ResourceCertificateParentChildValidator validator = ResourceValidatorFactory.getX509ResourceCertificateStrictValidator(context, options, result, crl);
         validator.validate(location, getCertificate());
-    }
-
-
-    private void checkManifestValidityTimes(ValidationOptions options, ValidationResult result) {
-        DateTime now = new DateTime();
-        DateTime nextUpdateTime = getNextUpdateTime();
-
-        if (now.isAfter(nextUpdateTime)) {
-            if (nextUpdateTime.plusDays(options.getMaxStaleDays()).isAfter(now)) {
-                result.warnIfTrue(true, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME);
-            } else {
-                result.rejectIfTrue(true, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME);
-            }
-        }
     }
 
     /**

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
@@ -62,20 +62,6 @@ public class X509CrlValidator implements CertificateRepositoryObjectValidator<X5
     public void validate(String location, X509Crl crl) {
         result.setLocation(new ValidationLocation(location));
         checkSignature(crl);
-        checkNextUpdate(crl);
-    }
-
-    private void checkNextUpdate(X509Crl crl) {
-        DateTime now = new DateTime();
-        DateTime nextUpdateTime = crl.getNextUpdateTime();
-
-        if (now.isAfter(nextUpdateTime)) {
-            if (nextUpdateTime.plusDays(options.getMaxStaleDays()).isAfter(now)) {
-                result.warnIfTrue(true, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
-            } else {
-                result.rejectIfTrue(true, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
-            }
-        }
     }
 
     private void checkSignature(X509Crl crl) {

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
@@ -62,6 +62,20 @@ public class X509CrlValidator implements CertificateRepositoryObjectValidator<X5
     public void validate(String location, X509Crl crl) {
         result.setLocation(new ValidationLocation(location));
         checkSignature(crl);
+        checkNextUpdate(crl);
+    }
+
+    private void checkNextUpdate(X509Crl crl) {
+        DateTime now = new DateTime();
+        DateTime nextUpdateTime = crl.getNextUpdateTime();
+
+        if (now.isAfter(nextUpdateTime)) {
+            if (nextUpdateTime.plusDays(options.getMaxStaleDays()).isAfter(now)) {
+                result.warnIfTrue(true, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
+            } else {
+                result.rejectIfTrue(true, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
+            }
+        }
     }
 
     private void checkSignature(X509Crl crl) {

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
@@ -70,11 +70,7 @@ public class X509CrlValidator implements CertificateRepositoryObjectValidator<X5
         DateTime nextUpdateTime = crl.getNextUpdateTime();
 
         if (now.isAfter(nextUpdateTime)) {
-            if (nextUpdateTime.plusDays(options.getMaxStaleDays()).isAfter(now)) {
-                result.warnIfTrue(true, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
-            } else {
-                result.rejectIfTrue(true, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
-            }
+            result.warnIfTrue(true, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
         }
     }
 

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
@@ -68,10 +68,7 @@ public class X509CrlValidator implements CertificateRepositoryObjectValidator<X5
     private void checkNextUpdate(X509Crl crl) {
         DateTime now = new DateTime();
         DateTime nextUpdateTime = crl.getNextUpdateTime();
-
-        if (now.isAfter(nextUpdateTime)) {
-            result.warnIfTrue(true, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
-        }
+        result.warnIfTrue(now.isAfter(nextUpdateTime), ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
     }
 
     private void checkSignature(X509Crl crl) {

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -237,15 +237,10 @@ public class ManifestCmsTest {
 
         subject.validate(ROOT_SIA_MANIFEST_RSYNC_LOCATION.toString(), context, crlLocator, options, result);
 
-        assertTrue(result.hasFailures());
-
-//        assertEquals(
-//                new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, NEXT_UPDATE_TIME.toString()),
-//                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.NOT_VALID_AFTER)
-//        );
+        assertFalse(result.hasFailures());
 
         assertEquals(
-                new ValidationCheck(ValidationStatus.ERROR, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME),
+                new ValidationCheck(ValidationStatus.WARNING, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME),
                 result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME)
         );
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -191,36 +191,7 @@ public class ManifestCmsTest {
     }
 
     @Test
-    public void shouldWarnWhenManifestIsStale() {
-        X509Crl crl = getRootCrl();
-
-        DateTimeUtils.setCurrentMillisFixed(NEXT_UPDATE_TIME.plusDays(1).getMillis());
-
-        IpResourceSet resources = rootCertificate.getResources();
-
-        CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
-
-        ValidationOptions options = new ValidationOptions();
-        options.setMaxStaleDays(Integer.MAX_VALUE);
-        ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
-
-        when(crlLocator.getCrl(ROOT_MANIFEST_CRL_LOCATION, context, result)).thenReturn(crl);
-
-        subject.validate(ROOT_SIA_MANIFEST_RSYNC_LOCATION.toString(), context, crlLocator, options, result);
-
-        assertFalse(result.hasFailures());
-        assertEquals(0, result.getFailuresForCurrentLocation().size());
-
-
-        assertEquals(
-                new ValidationCheck(ValidationStatus.WARNING, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME),
-                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME)
-        );
-    }
-
-
-    @Test
-    public void shouldRejectWhenManifestIsTooStale() {
+    public void shouldNotRejectWhenManifestIsTooStale() {
         X509Crl crl = getRootCrl();
 
         DateTimeUtils.setCurrentMillisFixed(NEXT_UPDATE_TIME.plusDays(1).getMillis());
@@ -237,17 +208,7 @@ public class ManifestCmsTest {
 
         subject.validate(ROOT_SIA_MANIFEST_RSYNC_LOCATION.toString(), context, crlLocator, options, result);
 
-        assertTrue(result.hasFailures());
-
-//        assertEquals(
-//                new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, NEXT_UPDATE_TIME.toString()),
-//                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.NOT_VALID_AFTER)
-//        );
-
-        assertEquals(
-                new ValidationCheck(ValidationStatus.ERROR, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME),
-                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME)
-        );
+        assertFalse(result.hasFailures());
     }
 
     @Test
@@ -269,11 +230,6 @@ public class ManifestCmsTest {
         subject.validate(ROOT_SIA_MANIFEST_RSYNC_LOCATION.toString(), context, crlLocator, options, result);
 
         assertTrue(result.hasFailures());
-
-        assertEquals(
-                new ValidationCheck(ValidationStatus.WARNING, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME),
-                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME)
-        );
 
         assertEquals(
                 new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, MFT_EE_NOT_AFTER.toString()),

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -191,7 +191,36 @@ public class ManifestCmsTest {
     }
 
     @Test
-    public void shouldNotRejectWhenManifestIsTooStale() {
+    public void shouldWarnWhenManifestIsStale() {
+        X509Crl crl = getRootCrl();
+
+        DateTimeUtils.setCurrentMillisFixed(NEXT_UPDATE_TIME.plusDays(1).getMillis());
+
+        IpResourceSet resources = rootCertificate.getResources();
+
+        CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
+
+        ValidationOptions options = new ValidationOptions();
+        options.setMaxStaleDays(Integer.MAX_VALUE);
+        ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
+
+        when(crlLocator.getCrl(ROOT_MANIFEST_CRL_LOCATION, context, result)).thenReturn(crl);
+
+        subject.validate(ROOT_SIA_MANIFEST_RSYNC_LOCATION.toString(), context, crlLocator, options, result);
+
+        assertFalse(result.hasFailures());
+        assertEquals(0, result.getFailuresForCurrentLocation().size());
+
+
+        assertEquals(
+                new ValidationCheck(ValidationStatus.WARNING, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME),
+                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME)
+        );
+    }
+
+
+    @Test
+    public void shouldRejectWhenManifestIsTooStale() {
         X509Crl crl = getRootCrl();
 
         DateTimeUtils.setCurrentMillisFixed(NEXT_UPDATE_TIME.plusDays(1).getMillis());
@@ -208,7 +237,17 @@ public class ManifestCmsTest {
 
         subject.validate(ROOT_SIA_MANIFEST_RSYNC_LOCATION.toString(), context, crlLocator, options, result);
 
-        assertFalse(result.hasFailures());
+        assertTrue(result.hasFailures());
+
+//        assertEquals(
+//                new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, NEXT_UPDATE_TIME.toString()),
+//                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.NOT_VALID_AFTER)
+//        );
+
+        assertEquals(
+                new ValidationCheck(ValidationStatus.ERROR, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME),
+                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME)
+        );
     }
 
     @Test
@@ -230,6 +269,11 @@ public class ManifestCmsTest {
         subject.validate(ROOT_SIA_MANIFEST_RSYNC_LOCATION.toString(), context, crlLocator, options, result);
 
         assertTrue(result.hasFailures());
+
+        assertEquals(
+                new ValidationCheck(ValidationStatus.WARNING, ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME),
+                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME)
+        );
 
         assertEquals(
                 new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, MFT_EE_NOT_AFTER.toString()),

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
@@ -55,7 +55,6 @@ import static org.junit.Assert.*;
 
 public class X509CrlValidatorTest {
 
-
     // Test data
     private static final X500Principal ROOT_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only, CN=RIPE NCC, C=NL");
     private static final IpResourceSet ROOT_RESOURCE_SET = IpResourceSet.parse("10.0.0.0/8, 192.168.0.0/16, ffce::/16, AS21212");
@@ -115,16 +114,14 @@ public class X509CrlValidatorTest {
     }
 
     @Test
-    public void shouldRejectWhenNextUpdateTooLongAgo() {
+    public void shouldNotRejectWhenNextUpdateTooLongAgo() {
         DateTime nextUpdateTime = new DateTime(DateTimeZone.UTC).minusSeconds(1).withMillisOfSecond(0);
         X509Crl crl = getRootCRL().withNextUpdateTime(nextUpdateTime).build(ROOT_KEY_PAIR.getPrivate());
         subject.validate("location", crl);
 
         result = subject.getValidationResult();
-        assertTrue(result.hasFailures());
-        assertEquals(new ValidationCheck(ValidationStatus.ERROR, CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString()), result.getResult(new ValidationLocation("location"), CRL_NEXT_UPDATE_BEFORE_NOW));
+        assertFalse(result.hasFailures());
     }
-
 
     private X509ResourceCertificate getRootResourceCertificate() {
         X509ResourceCertificateBuilder builder = new X509ResourceCertificateBuilder();

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
@@ -55,7 +55,6 @@ import static org.junit.Assert.*;
 
 public class X509CrlValidatorTest {
 
-
     // Test data
     private static final X500Principal ROOT_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only, CN=RIPE NCC, C=NL");
     private static final IpResourceSet ROOT_RESOURCE_SET = IpResourceSet.parse("10.0.0.0/8, 192.168.0.0/16, ffce::/16, AS21212");
@@ -101,8 +100,7 @@ public class X509CrlValidatorTest {
     }
 
     @Test
-    public void shouldWarnWhenNextUpdatePassedWithinMaxStaleDays() {
-
+    public void shouldNotWarnWhenNextUpdatePassedWithinMaxStaleDays() {
         options.setMaxStaleDays(1);
 
         DateTime nextUpdateTime = new DateTime(DateTimeZone.UTC).minusSeconds(1).withMillisOfSecond(0);
@@ -111,20 +109,17 @@ public class X509CrlValidatorTest {
 
         result = subject.getValidationResult();
         assertFalse(result.hasFailures());
-        assertEquals(new ValidationCheck(ValidationStatus.WARNING, CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString()), result.getResult(new ValidationLocation("location"), CRL_NEXT_UPDATE_BEFORE_NOW));
     }
 
     @Test
-    public void shouldRejectWhenNextUpdateTooLongAgo() {
+    public void shouldNotRejectWhenNextUpdateTooLongAgo() {
         DateTime nextUpdateTime = new DateTime(DateTimeZone.UTC).minusSeconds(1).withMillisOfSecond(0);
         X509Crl crl = getRootCRL().withNextUpdateTime(nextUpdateTime).build(ROOT_KEY_PAIR.getPrivate());
         subject.validate("location", crl);
 
         result = subject.getValidationResult();
-        assertTrue(result.hasFailures());
-        assertEquals(new ValidationCheck(ValidationStatus.ERROR, CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString()), result.getResult(new ValidationLocation("location"), CRL_NEXT_UPDATE_BEFORE_NOW));
+        assertFalse(result.hasFailures());
     }
-
 
     private X509ResourceCertificate getRootResourceCertificate() {
         X509ResourceCertificateBuilder builder = new X509ResourceCertificateBuilder();

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
@@ -55,6 +55,7 @@ import static org.junit.Assert.*;
 
 public class X509CrlValidatorTest {
 
+
     // Test data
     private static final X500Principal ROOT_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only, CN=RIPE NCC, C=NL");
     private static final IpResourceSet ROOT_RESOURCE_SET = IpResourceSet.parse("10.0.0.0/8, 192.168.0.0/16, ffce::/16, AS21212");
@@ -100,7 +101,8 @@ public class X509CrlValidatorTest {
     }
 
     @Test
-    public void shouldNotWarnWhenNextUpdatePassedWithinMaxStaleDays() {
+    public void shouldWarnWhenNextUpdatePassedWithinMaxStaleDays() {
+
         options.setMaxStaleDays(1);
 
         DateTime nextUpdateTime = new DateTime(DateTimeZone.UTC).minusSeconds(1).withMillisOfSecond(0);
@@ -109,17 +111,20 @@ public class X509CrlValidatorTest {
 
         result = subject.getValidationResult();
         assertFalse(result.hasFailures());
+        assertEquals(new ValidationCheck(ValidationStatus.WARNING, CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString()), result.getResult(new ValidationLocation("location"), CRL_NEXT_UPDATE_BEFORE_NOW));
     }
 
     @Test
-    public void shouldNotRejectWhenNextUpdateTooLongAgo() {
+    public void shouldRejectWhenNextUpdateTooLongAgo() {
         DateTime nextUpdateTime = new DateTime(DateTimeZone.UTC).minusSeconds(1).withMillisOfSecond(0);
         X509Crl crl = getRootCRL().withNextUpdateTime(nextUpdateTime).build(ROOT_KEY_PAIR.getPrivate());
         subject.validate("location", crl);
 
         result = subject.getValidationResult();
-        assertFalse(result.hasFailures());
+        assertTrue(result.hasFailures());
+        assertEquals(new ValidationCheck(ValidationStatus.ERROR, CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString()), result.getResult(new ValidationLocation("location"), CRL_NEXT_UPDATE_BEFORE_NOW));
     }
+
 
     private X509ResourceCertificate getRootResourceCertificate() {
         X509ResourceCertificateBuilder builder = new X509ResourceCertificateBuilder();

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
@@ -123,10 +123,12 @@ public class ProcessIscUpdownPdusTest {
 
         List<ValidationCheck> failures = result.getFailuresForAllLocations();
 
-        assertEquals(2, failures.size());
+        assertEquals(3, failures.size());
 
         failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, "2012-06-30T04:08:03.000Z"));
+        failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, "2012-06-30T04:07:24.000Z"));
         failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, "2012-06-30T04:07:24.000Z"));
+
     }
 
     @Test

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
@@ -123,12 +123,10 @@ public class ProcessIscUpdownPdusTest {
 
         List<ValidationCheck> failures = result.getFailuresForAllLocations();
 
-        assertEquals(3, failures.size());
+        assertEquals(2, failures.size());
 
         failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, "2012-06-30T04:08:03.000Z"));
-        failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, "2012-06-30T04:07:24.000Z"));
         failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, "2012-06-30T04:07:24.000Z"));
-
     }
 
     @Test


### PR DESCRIPTION
Just remove the code that is checking stale CRL/MFT until the MFT EE certificate is expired.

Please note: this check is completely removed, so there will not be any special error or warning even after EE certificate becomes invalid. In case we need to have a error message on the MFT/CRL in question and not just a validity error on EE certificate, I will change the PR.