### PR TITLE
Exclude cmsAlgorithmProtect extension from ProvisioningCmsObjectBuilder.

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectBuilder.java
@@ -29,12 +29,10 @@
  */
 package net.ripe.rpki.commons.crypto.cms;
 
-import net.ripe.rpki.commons.crypto.util.Asn1Util;
 import net.ripe.rpki.commons.crypto.util.BouncyCastleUtil;
 import net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper;
 import net.ripe.rpki.commons.crypto.x509cert.X509CertificateUtil;
 import org.apache.commons.lang.Validate;
-import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DERSet;
 import org.bouncycastle.asn1.cms.Attribute;
@@ -74,7 +72,7 @@ public abstract class RpkiSignedObjectBuilder {
         try {
             result = doGenerate(signingCertificate, privateKey, signatureProvider, contentTypeOid, content);
         } catch (NoSuchAlgorithmException | NoSuchProviderException | CMSException | IOException |
-                 InvalidAlgorithmParameterException | CertStoreException | CertificateEncodingException | OperatorCreationException e) {
+            InvalidAlgorithmParameterException | CertStoreException | CertificateEncodingException | OperatorCreationException e) {
             throw new RpkiSignedObjectBuilderException(e);
         }
         return result;

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/KeyStoreUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/KeyStoreUtil.java
@@ -48,15 +48,15 @@ import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.concurrent.Semaphore;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 
 public final class KeyStoreUtil {
@@ -147,27 +147,24 @@ public final class KeyStoreUtil {
     }
 
     private static KeyPair getKeyPairFromKeyStore(KeyStore keyStore) {
-        return withPermit(() -> {
-            try {
-                Certificate certificate = keyStore.getCertificateChain(KEYSTORE_KEY_ALIAS)[0];
-                PublicKey publicKey = certificate.getPublicKey();
-                PrivateKey privateKey = (PrivateKey) keyStore.getKey(KEYSTORE_KEY_ALIAS, KEYSTORE_PASSPHRASE);
-                return new KeyPair(publicKey, privateKey);
-            } catch (GeneralSecurityException e) {
-                throw new KeyStoreException(e);
-            }
-        });
+        try {
+            Certificate certificate = keyStore.getCertificateChain(KEYSTORE_KEY_ALIAS)[0];
+            PublicKey publicKey = certificate.getPublicKey();
+            PrivateKey privateKey = (PrivateKey) keyStore.getKey(KEYSTORE_KEY_ALIAS, KEYSTORE_PASSPHRASE);
+            return new KeyPair(publicKey, privateKey);
+        } catch (GeneralSecurityException e) {
+            throw new KeyStoreException(e);
+        }
     }
 
     private static KeyStore loadKeyStore(byte[] keyStoreData, String keyStoreProvider, String keyStoreType) {
-        return withPermit(() ->
-            loadKeyStore(keyStoreData, keyStoreProvider, keyStoreType, (keyStore, is) -> {
-                try {
-                    keyStore.load(new ByteArrayInputStream(keyStoreData), KEYSTORE_PASSPHRASE);
-                } catch (Exception e) {
-                    throw new KeyStoreException(e);
-                }
-            }));
+        return loadKeyStore(keyStoreData, keyStoreProvider, keyStoreType, (keyStore, is) -> {
+            try {
+                keyStore.load(new ByteArrayInputStream(keyStoreData), KEYSTORE_PASSPHRASE);
+            } catch (Exception e) {
+                throw new KeyStoreException(e);
+            }
+        });
     }
 
     private static KeyStore loadKeyStore(byte[] keyStoreData,
@@ -198,22 +195,6 @@ public final class KeyStoreUtil {
             return new JcaX509CertificateConverter().getCertificate(builder.build(sigGen));
         } catch (OperatorCreationException | CertificateException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    // temporary measure to restrict the amount of simultaneous requests to the HSM
-    private static Semaphore semaphore = new Semaphore(5);
-
-    private static <T> T withPermit(Supplier<T> s) {
-        try {
-            semaphore.acquire();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        try {
-            return s.get();
-        } finally {
-            semaphore.release();
         }
     }
 }

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilder.java
@@ -51,7 +51,6 @@ import org.bouncycastle.cms.CMSProcessableByteArray;
 import org.bouncycastle.cms.CMSSignedData;
 import org.bouncycastle.cms.CMSSignedDataGenerator;
 import org.bouncycastle.cms.DefaultSignedAttributeTableGenerator;
-import org.bouncycastle.cms.SignerInfoGenerator;
 import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.DigestCalculatorProvider;
@@ -151,15 +150,15 @@ public class ProvisioningCmsObjectBuilder {
         final ContentSigner signer = new JcaContentSignerBuilder(X509CertificateBuilderHelper.DEFAULT_SIGNATURE_ALGORITHM).setProvider(signatureProvider).build(privateKey);
         final DigestCalculatorProvider digestProvider = BouncyCastleUtil.DIGEST_CALCULATOR_PROVIDER;
         final byte[] ski = X509CertificateUtil.getSubjectKeyIdentifier(cmsCertificate);
-        final SignerInfoGenerator gen = new JcaSignerInfoGeneratorBuilder(digestProvider)
-            .setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(createSignedAttributes()) {
+        generator.addSignerInfoGenerator(
+            new JcaSignerInfoGeneratorBuilder(digestProvider)
+                .setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(createSignedAttributes()) {
                     @Override
                     public AttributeTable getAttributes(Map parameters) {
                         return super.getAttributes(parameters).remove(CMSAttributes.cmsAlgorithmProtect);
                     }
                 })
-            .build(signer, ski);
-        generator.addSignerInfoGenerator(gen);
+            .build(signer, ski));
     }
 
     private void addCertificateAndCrl(CMSSignedDataGenerator generator) throws CertificateEncodingException, CMSException, CRLException {

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilder.java
@@ -152,8 +152,7 @@ public class ProvisioningCmsObjectBuilder {
         final DigestCalculatorProvider digestProvider = BouncyCastleUtil.DIGEST_CALCULATOR_PROVIDER;
         final byte[] ski = X509CertificateUtil.getSubjectKeyIdentifier(cmsCertificate);
         final SignerInfoGenerator gen = new JcaSignerInfoGeneratorBuilder(digestProvider)
-            .setSignedAttributeGenerator(
-                new DefaultSignedAttributeTableGenerator(createSignedAttributes()) {
+            .setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(createSignedAttributes()) {
                     @Override
                     public AttributeTable getAttributes(Map parameters) {
                         return super.getAttributes(parameters).remove(CMSAttributes.cmsAlgorithmProtect);

--- a/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderTest.java
@@ -350,4 +350,15 @@ public class ProvisioningCmsObjectBuilderTest {
 
         assertNull(signer.getUnsignedAttributes());
     }
+
+    /**
+     * https://tools.ietf.org/html/draft-ietf-sidr-rescerts-provisioning-09#section-3.1.1.6.4
+     */
+    @Test
+    public void shouldCmsObjectHaveNoRedundantAttribute() throws Exception {
+        Collection<?> signers = signedDataParser.getSignerInfos().getSigners();
+        SignerInformation signer = (SignerInformation) signers.iterator().next();
+        AttributeTable attributeTable = signer.getSignedAttributes();
+        assertNull(attributeTable.get(CMSAttributes.cmsAlgorithmProtect));
+    }
 }


### PR DESCRIPTION
Fix the provisioning CMS by not adding extra signed attributes to it.