### PR TITLE
Fix ROA and MFT parsing

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
@@ -168,7 +168,6 @@ public final class ValidationString {
 
     //manifest
     public static final String MANIFEST_CONTENT_TYPE = "mf.content.type";
-    public static final String MANIFEST_CONTENT_SIZE = "mf.content.size";
     public static final String MANIFEST_CONTENT_STRUCTURE = "mf.content.structure";
     public static final String MANIFEST_TIME_FORMAT = "mf.time.format";
     public static final String MANIFEST_FILE_HASH_ALGORITHM = "mf.file.hash.algorithm";

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsTest.java
@@ -43,6 +43,7 @@ import net.ripe.rpki.commons.validation.ValidationResult;
 import net.ripe.rpki.commons.validation.objectvalidators.CertificateRepositoryObjectValidationContext;
 import org.joda.time.DateTime;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -148,6 +149,7 @@ public class RoaCmsTest {
     }
 
     @Test
+    @Ignore
     public void shouldUseNotValidBeforeTimeForSigningTime() {
         RoaCms roaCms = createRoaCms(allPrefixes);
         assertEquals(roaCms.getCertificate().getValidityPeriod().getNotValidBefore(), roaCms.getSigningTime());

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsTest.java
@@ -149,7 +149,6 @@ public class RoaCmsTest {
     }
 
     @Test
-    @Ignore
     public void shouldUseNotValidBeforeTimeForSigningTime() {
         RoaCms roaCms = createRoaCms(allPrefixes);
         assertEquals(roaCms.getCertificate().getValidityPeriod().getNotValidBefore(), roaCms.getSigningTime());

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
@@ -110,7 +110,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof RoaCms);
         assertEquals(roaCms, object);
-        assertEquals(45, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(46, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertFalse(validationResult.hasFailures());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
         assertEquals(ValidationStatus.WARNING, validationResult.getResultForCurrentLocation(CRLDP_OMITTED).getStatus());
@@ -139,7 +139,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof ManifestCms);
         assertEquals(manifestCms, object);
-        assertEquals(47, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(48, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertTrue(validationResult.hasNoFailuresOrWarnings());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
@@ -110,7 +110,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof RoaCms);
         assertEquals(roaCms, object);
-        assertEquals(49, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(45, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertFalse(validationResult.hasFailures());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
         assertEquals(ValidationStatus.WARNING, validationResult.getResultForCurrentLocation(CRLDP_OMITTED).getStatus());
@@ -139,7 +139,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof ManifestCms);
         assertEquals(manifestCms, object);
-        assertEquals(49, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(47, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertTrue(validationResult.hasNoFailuresOrWarnings());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
     }

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/CreateObjectsForInteropTesting.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/CreateObjectsForInteropTesting.java
@@ -40,6 +40,7 @@ import net.ripe.rpki.commons.provisioning.x509.ProvisioningIdentityCertificateBu
 import net.ripe.rpki.commons.validation.ValidationOptions;
 import net.ripe.rpki.commons.validation.ValidationResult;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;


### PR DESCRIPTION
We have incorrect implementation of ROA and MFT parsing that always think the version is omitted, so parsers break whenever version is there. This is to fix the issue. Also signingTime attribute is optional.