### PR TITLE
Setup options

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
@@ -160,12 +160,17 @@ public class ManifestCms extends RpkiSignedObject {
 
         result.rejectIfTrue(thisUpdateTime.isAfterNow(), ValidationString.MANIFEST_BEFORE_THIS_UPDATE_TIME, thisUpdateTime.toString());
 
-        boolean postGracePeriod = nextUpdateTime.plus(options.getManifestMaxStalePeriod()).isBeforeNow();
-        if (postGracePeriod) {
-            result.error(ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME, nextUpdateTime.toString());
+        if(options.isStrictManifestCRLValidityChecks()){
+            boolean postGracePeriod = nextUpdateTime.plus(options.getManifestMaxStalePeriod()).isBeforeNow();
+            if (postGracePeriod) {
+                result.error(ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME, nextUpdateTime.toString());
+            } else {
+                result.warnIfTrue(nextUpdateTime.isBeforeNow(), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME, nextUpdateTime.toString());
+            }
         } else {
             result.warnIfTrue(nextUpdateTime.isBeforeNow(), ValidationString.MANIFEST_PAST_NEXT_UPDATE_TIME, nextUpdateTime.toString());
         }
+
     }
 
     /**

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
@@ -72,10 +72,13 @@ public class X509CrlValidator implements CertificateRepositoryObjectValidator<X5
         DateTime thisUpdateTime = crl.getThisUpdateTime();
 
         result.rejectIfTrue(thisUpdateTime.isAfter(now), ValidationString.CRL_THIS_UPDATE_AFTER_NOW, thisUpdateTime.toString());
-
-        boolean postGracePeriod = now.isAfter(nextUpdateTime.plus(options.getCrlMaxStalePeriod()));
-        if (postGracePeriod) {
-            result.error(ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
+        if (options.isStrictManifestCRLValidityChecks()) {
+            boolean postGracePeriod = now.isAfter(nextUpdateTime.plus(options.getCrlMaxStalePeriod()));
+            if (postGracePeriod) {
+                result.error(ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
+            } else {
+                result.warnIfTrue(now.isAfter(nextUpdateTime), ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
+            }
         } else {
             result.warnIfTrue(now.isAfter(nextUpdateTime), ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, nextUpdateTime.toString());
         }

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -36,16 +36,36 @@ import org.joda.time.Duration;
  * User controlled options to use when validating objects.
  */
 public class ValidationOptions {
-    private Duration crlMaxStalePeriod = Duration.standardHours(12);
+
     /**
-     * Grace period for the NEXT_UPDATE_TIME of Manifest. When a manifest is in the grace period, the manifest causes
-     * a warning on validation instead of a failure.
+     * Flag to switch whether we would reject stale manifest and CRL under certain max stale period.
+     * Turning this on will activate the {@link ValidationOptions#crlMaxStalePeriod} and {@link ValidationOptions#manifestMaxStalePeriod} checks.
+     *
+     */
+    private boolean strictManifestCRLValidityChecks = false;
+
+    /**
+     * When {@link ValidationOptions#strictManifestCRLValidityChecks} is enabled, this is the grace period for the
+     * NEXT_UPDATE_TIME of CRL. When a crl is in the grace period, the crl causes a warning on
+     * validation instead of a failure.
+     */
+    private Duration crlMaxStalePeriod = Duration.ZERO;
+
+    /**
+     *  When {@link ValidationOptions#strictManifestCRLValidityChecks} is enabled, this is the grace period for the
+     *  NEXT_UPDATE_TIME of Manifest. When a manifest is in the grace period, the manifest causes
+     *  a warning on validation instead of a failure.
      *
      * This grace period is not applied to the EE certificate.
      */
-    private Duration manifestMaxStalePeriod = Duration.standardHours(12);
+    private Duration manifestMaxStalePeriod = Duration.ZERO;
 
-    private boolean looseValidationEnabled = false;
+    /**
+     * Setting this will allow resources over claim on X509ResourceCertificateParentChildLooseValidator.
+     * Instead of rejected, it will only produce warnin on overclaim of child resources.
+     */
+    private boolean allowOverclaimParentChild = false;
+
 
     public Duration getCrlMaxStalePeriod() {
         return this.crlMaxStalePeriod;
@@ -63,11 +83,19 @@ public class ValidationOptions {
         this.manifestMaxStalePeriod = maxStalePeriod;
     }
 
-    public boolean isLooseValidationEnabled() {
-        return looseValidationEnabled;
+    public boolean isAllowOverclaimParentChild() {
+        return allowOverclaimParentChild;
     }
 
-    public void setLooseValidationEnabled(boolean looseValidationEnabled) {
-        this.looseValidationEnabled = looseValidationEnabled;
+    public void setAllowOverclaimParentChild(boolean allowOverclaimParentChild) {
+        this.allowOverclaimParentChild = allowOverclaimParentChild;
+    }
+
+    public boolean isStrictManifestCRLValidityChecks() {
+        return strictManifestCRLValidityChecks;
+    }
+
+    public void setStrictManifestCRLValidityChecks(boolean strictManifestCRLValidityChecks) {
+        this.strictManifestCRLValidityChecks = strictManifestCRLValidityChecks;
     }
 }

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -36,14 +36,14 @@ import org.joda.time.Duration;
  * User controlled options to use when validating objects.
  */
 public class ValidationOptions {
-    private Duration crlMaxStalePeriod = Duration.ZERO;
+    private Duration crlMaxStalePeriod = Duration.standardHours(12);
     /**
      * Grace period for the NEXT_UPDATE_TIME of Manifest. When a manifest is in the grace period, the manifest causes
      * a warning on validation instead of a failure.
      *
      * This grace period is not applied to the EE certificate.
      */
-    private Duration manifestMaxStalePeriod = Duration.ZERO;
+    private Duration manifestMaxStalePeriod = Duration.standardHours(12);
 
     private boolean looseValidationEnabled = false;
 

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -76,8 +76,9 @@ public class ValidationOptions {
     }
 
     /**
-     * RIPE regularly refresh Crl/Manifest in our RPKI core every 16 hours, with validity for 8 hours.
-     * This one will invalidates a crl/manifest with still 7 hours remaining, indicating something wrong with refresh.
+     * RIPE regularly refresh Crl/Manifest in our RPKI core every 16 hours,with validity for 24 hours.
+     * Leaving 8 for troubleshooting if needed. This one will invalidates a crl/manifest with still 7 hours
+     * remaining, indicating something wrong with refresh.
      * @return
      */
     public static ValidationOptions strictValidations() {

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -88,25 +88,16 @@ public class ValidationOptions {
         return new ValidationOptions();
     }
 
+    public static ValidationOptions withStaleConfigurations(Duration maxCrlStalePeriod, Duration maxMftStalePeriod) {
+        return new ValidationOptions(true, maxCrlStalePeriod, maxMftStalePeriod);
+    }
+
     public Duration getCrlMaxStalePeriod() {
         return this.crlMaxStalePeriod;
     }
 
     public Duration getManifestMaxStalePeriod() {
         return manifestMaxStalePeriod;
-    }
-
-    public void setCrlMaxStalePeriod(Duration maxStalePeriod) {
-        if(!strictManifestCRLValidityChecks)
-            throw new IllegalArgumentException("You need to set strictManifestCrlValidity check to use this option.");
-        this.crlMaxStalePeriod = maxStalePeriod;
-    }
-
-    public void setManifestMaxStalePeriod(Duration maxStalePeriod) {
-        if(!strictManifestCRLValidityChecks)
-            throw new IllegalArgumentException("You need to set strictManifestCrlValidity check to use this option.");
-
-        this.manifestMaxStalePeriod = maxStalePeriod;
     }
 
     public boolean isAllowOverclaimParentChild() {

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -66,6 +66,27 @@ public class ValidationOptions {
      */
     private boolean allowOverclaimParentChild = false;
 
+    public ValidationOptions() { }
+
+    private ValidationOptions(Boolean strictManifestCRLValidityChecks, Duration crlMaxStalePeriod,
+                              Duration manifestMaxStalePeriod){
+        this.strictManifestCRLValidityChecks = strictManifestCRLValidityChecks;
+        this.crlMaxStalePeriod = crlMaxStalePeriod;
+        this.manifestMaxStalePeriod = manifestMaxStalePeriod;
+    }
+
+    /**
+     * RIPE regularly refresh Crl/Manifest in our RPKI core every 16 hours, with validity for 8 hours.
+     * This one will invalidates a crl/manifest with still 7 hours remaining, indicating something wrong with refresh.
+     * @return
+     */
+    public static ValidationOptions paranoidOptions() {
+        return new ValidationOptions(true, Duration.standardHours(-7), Duration.standardHours(-7));
+    }
+
+    public static ValidationOptions defaultRipeNccValidator() {
+        return new ValidationOptions();
+    }
 
     public Duration getCrlMaxStalePeriod() {
         return this.crlMaxStalePeriod;

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -76,10 +76,15 @@ public class ValidationOptions {
     }
 
     public void setCrlMaxStalePeriod(Duration maxStalePeriod) {
+        if(!strictManifestCRLValidityChecks)
+            throw new IllegalArgumentException("You need to set strictManifestCrlValidity check to use this option.");
         this.crlMaxStalePeriod = maxStalePeriod;
     }
 
     public void setManifestMaxStalePeriod(Duration maxStalePeriod) {
+        if(!strictManifestCRLValidityChecks)
+            throw new IllegalArgumentException("You need to set strictManifestCrlValidity check to use this option.");
+
         this.manifestMaxStalePeriod = maxStalePeriod;
     }
 

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -80,7 +80,7 @@ public class ValidationOptions {
      * This one will invalidates a crl/manifest with still 7 hours remaining, indicating something wrong with refresh.
      * @return
      */
-    public static ValidationOptions paranoidOptions() {
+    public static ValidationOptions strictValidations() {
         return new ValidationOptions(true, Duration.standardHours(-7), Duration.standardHours(-7));
     }
 

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/ResourceValidatorFactory.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/ResourceValidatorFactory.java
@@ -48,7 +48,7 @@ public class ResourceValidatorFactory {
             CertificateRepositoryObjectValidationContext context,
             ValidationOptions options, ValidationResult result, X509Crl crl) {
 
-        if (options.isLooseValidationEnabled())
+        if (options.isAllowOverclaimParentChild())
             return new X509ResourceCertificateParentChildLooseValidator(options, result, crl, context);
 
         return new X509ResourceCertificateParentChildValidator(options, result, context.getCertificate(), crl, context.getResources());

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -203,6 +203,7 @@ public class ManifestCmsTest {
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
         ValidationOptions options = new ValidationOptions();
+        options.setStrictManifestCRLValidityChecks(true);
         options.setManifestMaxStalePeriod(Duration.standardDays(100 * 365));
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
@@ -231,6 +232,7 @@ public class ManifestCmsTest {
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
         ValidationOptions options = new ValidationOptions();
+        options.setStrictManifestCRLValidityChecks(true);
         options.setManifestMaxStalePeriod(Duration.standardDays(-2));
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
@@ -257,6 +259,7 @@ public class ManifestCmsTest {
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
         ValidationOptions options = new ValidationOptions();
+        options.setStrictManifestCRLValidityChecks(true);
         options.setManifestMaxStalePeriod(Duration.ZERO);
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -202,9 +202,7 @@ public class ManifestCmsTest {
 
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
-        ValidationOptions options = new ValidationOptions();
-        options.setStrictManifestCRLValidityChecks(true);
-        options.setManifestMaxStalePeriod(Duration.standardDays(100 * 365));
+        ValidationOptions options = ValidationOptions.withStaleConfigurations(Duration.ZERO, Duration.standardDays(100 * 365));
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
         when(crlLocator.getCrl(ROOT_MANIFEST_CRL_LOCATION, context, result)).thenReturn(crl);
@@ -231,9 +229,7 @@ public class ManifestCmsTest {
 
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
-        ValidationOptions options = new ValidationOptions();
-        options.setStrictManifestCRLValidityChecks(true);
-        options.setManifestMaxStalePeriod(Duration.standardDays(-2));
+        ValidationOptions options = ValidationOptions.withStaleConfigurations(Duration.ZERO, Duration.standardDays(-2));
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
         when(crlLocator.getCrl(ROOT_MANIFEST_CRL_LOCATION, context, result)).thenReturn(crl);
@@ -258,9 +254,7 @@ public class ManifestCmsTest {
 
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
-        ValidationOptions options = new ValidationOptions();
-        options.setStrictManifestCRLValidityChecks(true);
-        options.setManifestMaxStalePeriod(Duration.ZERO);
+        ValidationOptions options = ValidationOptions.withStaleConfigurations(Duration.ZERO,Duration.ZERO);
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
         when(crlLocator.getCrl(ROOT_MANIFEST_CRL_LOCATION, context, result)).thenReturn(crl);
@@ -288,9 +282,7 @@ public class ManifestCmsTest {
 
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
-        ValidationOptions options = new ValidationOptions();
-        options.setStrictManifestCRLValidityChecks(true);
-        options.setManifestMaxStalePeriod(Duration.standardDays(100));
+        ValidationOptions options = ValidationOptions.withStaleConfigurations(Duration.ZERO, Duration.standardDays(100));
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
         when(crlLocator.getCrl(ROOT_MANIFEST_CRL_LOCATION, context, result)).thenReturn(crl);
@@ -323,7 +315,7 @@ public class ManifestCmsTest {
 
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
-        ValidationOptions options = new ValidationOptions();
+        ValidationOptions options = ValidationOptions.defaultRipeNccValidator();
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
         when(crlLocator.getCrl(ROOT_MANIFEST_CRL_LOCATION, context, result)).thenReturn(crl);

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -289,6 +289,7 @@ public class ManifestCmsTest {
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
         ValidationOptions options = new ValidationOptions();
+        options.setStrictManifestCRLValidityChecks(true);
         options.setManifestMaxStalePeriod(Duration.standardDays(100));
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
@@ -120,6 +120,7 @@ public class X509CrlValidatorTest {
 
     @Test
     public void shouldWarnWhenNextUpdatePassedWithinMaxStaleDays() {
+        options.setStrictManifestCRLValidityChecks(true);
         options.setCrlMaxStalePeriod(Duration.standardDays(1));
 
         DateTime nextUpdateTime = UTC.dateTime().minusSeconds(1).withMillisOfSecond(0);

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
@@ -133,6 +133,7 @@ public class X509CrlValidatorTest {
 
     @Test
     public void shouldRejectWhenNextUpdateOutsideMaxStaleDays() {
+        options.setStrictManifestCRLValidityChecks(true);
         options.setCrlMaxStalePeriod(Duration.standardDays(1));
 
         DateTime nextUpdateTime = UTC.dateTime().minusDays(2).withMillisOfSecond(0); // Truncate millis
@@ -146,6 +147,7 @@ public class X509CrlValidatorTest {
 
     @Test
     public void shouldRejectWhenNextUpdateOutsideNegativeMaxStaleDays() {
+        options.setStrictManifestCRLValidityChecks(true);
         options.setCrlMaxStalePeriod(Duration.standardDays(-8));
 
         DateTime nextUpdateTime = UTC.dateTime().withMillisOfSecond(0); // Truncate millis

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
@@ -120,8 +120,7 @@ public class X509CrlValidatorTest {
 
     @Test
     public void shouldWarnWhenNextUpdatePassedWithinMaxStaleDays() {
-        options.setStrictManifestCRLValidityChecks(true);
-        options.setCrlMaxStalePeriod(Duration.standardDays(1));
+        options = ValidationOptions.withStaleConfigurations(Duration.standardDays(1), Duration.ZERO);
 
         DateTime nextUpdateTime = UTC.dateTime().minusSeconds(1).withMillisOfSecond(0);
         X509Crl crl = getRootCRL().withNextUpdateTime(nextUpdateTime).build(ROOT_KEY_PAIR.getPrivate());
@@ -134,9 +133,8 @@ public class X509CrlValidatorTest {
 
     @Test
     public void shouldRejectWhenNextUpdateOutsideMaxStaleDays() {
-        options.setStrictManifestCRLValidityChecks(true);
-        options.setCrlMaxStalePeriod(Duration.standardDays(1));
-
+        options = ValidationOptions.withStaleConfigurations(Duration.standardDays(1), Duration.ZERO);
+        subject = new X509CrlValidator(options, result, parent);
         DateTime nextUpdateTime = UTC.dateTime().minusDays(2).withMillisOfSecond(0); // Truncate millis
         X509Crl crl = getRootCRL().withNextUpdateTime(nextUpdateTime).build(ROOT_KEY_PAIR.getPrivate());
         subject.validate("location", crl);
@@ -148,9 +146,8 @@ public class X509CrlValidatorTest {
 
     @Test
     public void shouldRejectWhenNextUpdateOutsideNegativeMaxStaleDays() {
-        options.setStrictManifestCRLValidityChecks(true);
-        options.setCrlMaxStalePeriod(Duration.standardDays(-8));
-
+        options = ValidationOptions.withStaleConfigurations(Duration.standardDays(-8), Duration.ZERO);
+        subject = new X509CrlValidator(options, result, parent);
         DateTime nextUpdateTime = UTC.dateTime().withMillisOfSecond(0); // Truncate millis
         X509Crl crl = getRootCRL().withNextUpdateTime(nextUpdateTime).build(ROOT_KEY_PAIR.getPrivate());
         subject.validate("location", crl);

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
@@ -126,9 +126,8 @@ public class ProcessIscUpdownPdusTest {
 
         List<ValidationCheck> failures = result.getFailuresForAllLocations();
 
-        assertEquals(3, failures.size());
+        assertEquals(2, failures.size());
 
-        assertTrue(failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.CRL_NEXT_UPDATE_BEFORE_NOW, "2012-06-30T04:07:24.000Z")));
         assertTrue(failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, "2012-06-30T04:08:03.000Z")));
         assertTrue(failures.contains(new ValidationCheck(ValidationStatus.ERROR, ValidationString.NOT_VALID_AFTER, "2012-06-30T04:07:24.000Z")));
     }


### PR DESCRIPTION
Introduce strict check manifest and crl validity, to enable/disable max stale checking for crl and manifest.

Rename loose validation into allow overlaps, to make it distinct/clear.