### PR TITLE
Performance improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.ripe.rpki</groupId>
     <artifactId>rpki-commons</artifactId>
-    <version>1.10-SNAPSHOT</version>
+    <version>1.11-SNAPSHOT</version>
     <inceptionYear>2008</inceptionYear>
 
     <name>RPKI Commmons</name>

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/Asn1Util.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/Asn1Util.java
@@ -109,10 +109,18 @@ public final class Asn1Util {
      *                                  class.
      */
     public static <T extends ASN1Encodable> T expect(ASN1Encodable value, Class<? extends T> expectedClass) {
-        Validate.notNull(value, expectedClass.getSimpleName() + " expected, got null");
-        Validate.isTrue(expectedClass.isInstance(value), expectedClass.getSimpleName() + " expected, got " + value.getClass().getSimpleName()
-                + " with value: " + value);
-        return expectedClass.cast(value);
+        if (value != null) {
+            try {
+                return expectedClass.cast(value);
+            } catch (ClassCastException e) {
+                throw new IllegalArgumentException(
+                        expectedClass.getSimpleName() + " expected, got " + value.getClass().getSimpleName() +
+                                " with value: " + value
+                );
+            }
+        } else {
+            throw new IllegalArgumentException(expectedClass.getSimpleName() + " expected, got null");
+        }
     }
 
     /**

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/AbstractX509CertificateWrapper.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/AbstractX509CertificateWrapper.java
@@ -60,10 +60,12 @@ public abstract class AbstractX509CertificateWrapper implements Serializable {
 
     private final X509Certificate certificate;
 
+    private final boolean ca;
 
     protected AbstractX509CertificateWrapper(X509Certificate certificate) {
         Validate.notNull(certificate);
         this.certificate = certificate;
+        this.ca = X509CertificateUtil.isCa(certificate);
     }
 
     public X509Certificate getCertificate() {
@@ -105,11 +107,11 @@ public abstract class AbstractX509CertificateWrapper implements Serializable {
     }
 
     public boolean isEe() {
-        return X509CertificateUtil.isEe(certificate);
+        return !isCa();
     }
 
     public boolean isCa() {
-        return X509CertificateUtil.isCa(certificate);
+        return ca;
     }
 
     public boolean isRoot() {

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateParser.java
@@ -47,6 +47,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.List;
+import java.util.Set;
 
 import static net.ripe.rpki.commons.validation.ValidationString.CERTIFICATE_PARSED;
 import static net.ripe.rpki.commons.validation.ValidationString.CERTIFICATE_SIGNATURE_ALGORITHM;
@@ -175,12 +176,13 @@ public abstract class X509CertificateParser<T extends AbstractX509CertificateWra
     }
 
     protected boolean isResourceExtensionPresent() {
-        if (certificate.getCriticalExtensionOIDs() == null) {
+        Set<String> criticalExtensionOIDs = certificate.getCriticalExtensionOIDs();
+        if (criticalExtensionOIDs == null) {
             return false;
         }
 
-        return certificate.getCriticalExtensionOIDs().contains(ResourceExtensionEncoder.OID_AUTONOMOUS_SYS_IDS.getId())
-                || certificate.getCriticalExtensionOIDs().contains(ResourceExtensionEncoder.OID_IP_ADDRESS_BLOCKS.getId());
+        return criticalExtensionOIDs.contains(ResourceExtensionEncoder.OID_AUTONOMOUS_SYS_IDS.getId())
+                || criticalExtensionOIDs.contains(ResourceExtensionEncoder.OID_IP_ADDRESS_BLOCKS.getId());
     }
 
     protected boolean isIpResourceExtensionPresent() {


### PR DESCRIPTION
Mainly reduce the amount of garbage generated for some commonly used functions. Speeds up the RPKI validator 3 by about 5%-10% when performing a full trust anchor validation.