### PR TITLE
Make ValidationOptions static constructors matching the reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ provisioning protocol.
 
 ## Changelog
 
+### 2020-07 version 1.12.2
+
+Fix inconsistencies in ValidationOptions behaviour.
+
 ### 2020-07 version 1.12.0
 
 Provide option to avoid storing passed checks in validation result to

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ provisioning protocol.
 
 ## Changelog
 
-### 2020-07 version 1.12.2
+### 2020-07 version 1.12.1
 
 Fix inconsistencies in ValidationOptions behaviour.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ provisioning protocol.
 
 ## Changelog
 
-### 2020-07 version 1.12.1
+### 2020-07 version 1.13
 
 Fix inconsistencies in ValidationOptions behaviour.
 

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectValidator.java
@@ -71,7 +71,7 @@ public class ProvisioningCmsObjectValidator {
     }
 
     private void validateCrl() {
-        X509CrlValidator crlValidator = new X509CrlValidator(new ValidationOptions(), validationResult, identityCertificate);
+        X509CrlValidator crlValidator = new X509CrlValidator(options, validationResult, identityCertificate);
         crlValidator.validate("<crl>", crl);
     }
 

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -42,14 +42,14 @@ public class ValidationOptions {
      * Turning this on will activate the {@link ValidationOptions#crlMaxStalePeriod} and {@link ValidationOptions#manifestMaxStalePeriod} checks.
      *
      */
-    private boolean strictManifestCRLValidityChecks = false;
+    private boolean strictManifestCRLValidityChecks;
 
     /**
      * When {@link ValidationOptions#strictManifestCRLValidityChecks} is enabled, this is the grace period for the
      * NEXT_UPDATE_TIME of CRL. When a crl is in the grace period, the crl causes a warning on
      * validation instead of a failure.
      */
-    private Duration crlMaxStalePeriod = Duration.ZERO;
+    private Duration crlMaxStalePeriod;
 
     /**
      *  When {@link ValidationOptions#strictManifestCRLValidityChecks} is enabled, this is the grace period for the
@@ -58,35 +58,48 @@ public class ValidationOptions {
      *
      * This grace period is not applied to the EE certificate.
      */
-    private Duration manifestMaxStalePeriod = Duration.ZERO;
+    private Duration manifestMaxStalePeriod;
 
     /**
      * Setting this will allow resources over claim on X509ResourceCertificateParentChildLooseValidator.
-     * Instead of rejected, it will only produce warnin on overclaim of child resources.
+     * Instead of rejected, it will only produce warning on overclaim of child resources.
      */
     private boolean allowOverclaimParentChild = false;
 
-    public ValidationOptions() { }
-
     private ValidationOptions(Boolean strictManifestCRLValidityChecks, Duration crlMaxStalePeriod,
-                              Duration manifestMaxStalePeriod){
+                              Duration manifestMaxStalePeriod) {
         this.strictManifestCRLValidityChecks = strictManifestCRLValidityChecks;
         this.crlMaxStalePeriod = crlMaxStalePeriod;
         this.manifestMaxStalePeriod = manifestMaxStalePeriod;
     }
 
     /**
+     * Validate manifest in a strict way, i.e. the whole manifest is considered invalid if any of the references
+     * on it are not found in the downloaded data or cache. Set grace periods to 0.
+     */
+    public static ValidationOptions strictValidation() {
+        return new ValidationOptions(true, Duration.ZERO, Duration.ZERO);
+    }
+
+    /**
+     * Validate manifest in a non-strict way, i.e. the if any of the references on it are not found, a warning is
+     * emitted and the validation process continues for the correct references. Set grace periods to 0.
+     */
+    public static ValidationOptions backCompatibleRipeNccValidator() {
+        return new ValidationOptions(false, Duration.ZERO, Duration.ZERO);
+    }
+
+    /**
+     * This mode is introduced for internal testing purposes.
+     * <p>
      * RIPE regularly refresh Crl/Manifest in our RPKI core every 16 hours,with validity for 24 hours.
      * Leaving 8 for troubleshooting if needed. This one will invalidates a crl/manifest with still 7 hours
      * remaining, indicating something wrong with refresh.
+     *
      * @return
      */
-    public static ValidationOptions strictValidations() {
+    public static ValidationOptions paranoidTestValidations() {
         return new ValidationOptions(true, Duration.standardHours(-7), Duration.standardHours(-7));
-    }
-
-    public static ValidationOptions defaultRipeNccValidator() {
-        return new ValidationOptions();
     }
 
     public static ValidationOptions withStaleConfigurations(Duration maxCrlStalePeriod, Duration maxMftStalePeriod) {

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateBottomUpValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateBottomUpValidator.java
@@ -52,7 +52,7 @@ public class X509ResourceCertificateBottomUpValidator implements X509ResourceCer
     private X509ResourceCertificate certificate;
     private Collection<X509ResourceCertificate> trustAnchors;
     private ResourceCertificateLocator locator;
-    private List<CertificateWithLocation> certificates = new LinkedList<CertificateWithLocation>();
+    private List<CertificateWithLocation> certificates = new LinkedList<>();
     private ValidationOptions options;
     private ValidationResult result;
     private ValidationLocation location;
@@ -63,7 +63,7 @@ public class X509ResourceCertificateBottomUpValidator implements X509ResourceCer
     }
 
     public X509ResourceCertificateBottomUpValidator(ResourceCertificateLocator locator, Collection<X509ResourceCertificate> trustAnchors) {
-        this(new ValidationOptions(), ValidationResult.withLocation("unknown.cer"), locator, trustAnchors);
+        this(ValidationOptions.strictValidation(), ValidationResult.withLocation("unknown.cer"), locator, trustAnchors);
     }
 
     public X509ResourceCertificateBottomUpValidator(ValidationOptions options, ValidationResult result, ResourceCertificateLocator locator, Collection<X509ResourceCertificate> trustAnchors) {

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -111,7 +111,7 @@ public class ManifestCmsTest {
     private ManifestCms subject;
     private X509ResourceCertificate rootCertificate;
 
-    private static final ValidationOptions VALIDATION_OPTIONS = new ValidationOptions();
+    private static final ValidationOptions VALIDATION_OPTIONS = ValidationOptions.strictValidation();
 
     public static ManifestCms getRootManifestCms() {
         ManifestCmsBuilder builder = getRootManifestBuilder();
@@ -315,7 +315,7 @@ public class ManifestCmsTest {
 
         CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
 
-        ValidationOptions options = ValidationOptions.defaultRipeNccValidator();
+        ValidationOptions options = ValidationOptions.backCompatibleRipeNccValidator();
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
         when(crlLocator.getCrl(ROOT_MANIFEST_CRL_LOCATION, context, result)).thenReturn(crl);

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsTest.java
@@ -172,7 +172,7 @@ public class RoaCmsTest {
         CrlLocator crlLocator = Mockito.mock(CrlLocator.class);
         Mockito.when(crlLocator.getCrl(Mockito.any(URI.class), Mockito.any(CertificateRepositoryObjectValidationContext.class), Mockito.any(ValidationResult.class))).thenReturn(crl);
 
-        subject.validate(TEST_ROA_LOCATION.toString(), validationContext, crlLocator, new ValidationOptions(), ValidationResult.withLocation(TEST_ROA_LOCATION));
+        subject.validate(TEST_ROA_LOCATION.toString(), validationContext, crlLocator, ValidationOptions.strictValidation(), ValidationResult.withLocation(TEST_ROA_LOCATION));
 
         assertTrue("ROA must be revoked", subject.isRevoked());
     }
@@ -189,7 +189,7 @@ public class RoaCmsTest {
         CrlLocator crlLocator = Mockito.mock(CrlLocator.class);
         Mockito.when(crlLocator.getCrl(Mockito.any(URI.class), Mockito.any(CertificateRepositoryObjectValidationContext.class), Mockito.any(ValidationResult.class))).thenReturn(crl);
 
-        subject.validate(TEST_ROA_LOCATION.toString(), validationContext, crlLocator, new ValidationOptions(), ValidationResult.withLocation(TEST_ROA_LOCATION));
+        subject.validate(TEST_ROA_LOCATION.toString(), validationContext, crlLocator, ValidationOptions.strictValidation(), ValidationResult.withLocation(TEST_ROA_LOCATION));
 
         assertFalse("ROA must not be revoked", subject.isRevoked());
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlTest.java
@@ -55,7 +55,7 @@ public class X509CrlTest {
 
     private static final URI ROOT_MANIFEST_CRL_LOCATION = URI.create("rsync://foo.host/bar/bar%20space.crl");
 
-    private static final ValidationOptions VALIDATION_OPTIONS = new ValidationOptions();
+    private static final ValidationOptions VALIDATION_OPTIONS = ValidationOptions.strictValidation();
 
 
     public static X509Crl createCrl() {

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
@@ -80,7 +80,7 @@ public class X509CrlValidatorTest {
     @Before
     public void setUp() {
         parent = getRootResourceCertificate();
-        options = new ValidationOptions();
+        options = ValidationOptions.backCompatibleRipeNccValidator();
         result = ValidationResult.withLocation("location");
         subject = new X509CrlValidator(options, result, parent);
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateTest.java
@@ -93,7 +93,7 @@ public class X509ResourceCertificateTest {
 
     private static final BigInteger TEST_SERIAL_NUMBER = BigInteger.valueOf(900);
 
-    private static final ValidationOptions VALIDATION_OPTIONS = new ValidationOptions();
+    private static final ValidationOptions VALIDATION_OPTIONS = ValidationOptions.strictValidation();
 
     public static X509ResourceCertificateBuilder createSelfSignedCaCertificateBuilder() {
         X509ResourceCertificateBuilder builder = createBasicBuilder();
@@ -374,7 +374,7 @@ public class X509ResourceCertificateTest {
 
         CertificateRepositoryObjectValidationContext validationContext = new CertificateRepositoryObjectValidationContext(TEST_TA_URI, rootCert);
 
-        subject.validate(TEST_CA_URI.toString(), validationContext, crlLocator, new ValidationOptions(), ValidationResult.withLocation(TEST_CA_URI));
+        subject.validate(TEST_CA_URI.toString(), validationContext, crlLocator, ValidationOptions.strictValidation(), ValidationResult.withLocation(TEST_CA_URI));
 
         assertTrue("Certificate must be revoked", subject.isRevoked());
 

--- a/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectValidatorTest.java
@@ -48,7 +48,7 @@ public class ProvisioningCmsObjectValidatorTest {
 
     private ProvisioningCmsObjectValidator subject;
 
-    private ValidationOptions options = new ValidationOptions();
+    private ValidationOptions options = ValidationOptions.strictValidation();
 
 
     @Before

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/CreateObjectsForInteropTesting.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/CreateObjectsForInteropTesting.java
@@ -83,7 +83,7 @@ public class CreateObjectsForInteropTesting {
     }
 
     public void validateCmsObject(ProvisioningCmsObject resourceClassListQueryCms) {
-        ProvisioningCmsObjectValidator validator = new ProvisioningCmsObjectValidator(new ValidationOptions(), resourceClassListQueryCms, ProvisioningIdentityCertificateBuilderTest.TEST_IDENTITY_CERT);
+        ProvisioningCmsObjectValidator validator = new ProvisioningCmsObjectValidator(ValidationOptions.strictValidation(), resourceClassListQueryCms, ProvisioningIdentityCertificateBuilderTest.TEST_IDENTITY_CERT);
         ValidationResult result = ValidationResult.withLocation("n/a");
         validator.validate(result);
         assertTrue(!result.hasFailures());

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
@@ -120,7 +120,8 @@ public class ProcessIscUpdownPdusTest {
 
         ProvisioningIdentityCertificate childCert = extractCarolIdentityCert();
 
-        ProvisioningCmsObjectValidator validator = new ProvisioningCmsObjectValidator(new ValidationOptions(), provisioningCmsObject, childCert);
+        ProvisioningCmsObjectValidator validator = new ProvisioningCmsObjectValidator(
+            ValidationOptions.backCompatibleRipeNccValidator(), provisioningCmsObject, childCert);
         ValidationResult result = ValidationResult.withLocation("unknown.der");
         validator.validate(result);
 

--- a/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateParentChildValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateParentChildValidatorTest.java
@@ -88,7 +88,7 @@ public class X509ResourceCertificateParentChildValidatorTest {
         child = createChildCertificateBuilder().build();
         rootCrl = getRootCRL().build(ROOT_KEY_PAIR.getPrivate());
         result = ValidationResult.withLocation("n/a");
-        options = new ValidationOptions();
+        options = ValidationOptions.strictValidation();
     }
 
     private void validate(X509ResourceCertificateParentChildValidator validator, X509ResourceCertificate certificate) {


### PR DESCRIPTION
At the moment we have ValidationOptions.strictValidation() that was introduced for paranoidal testing of RIPE NCC's repository, but got into production validator and introduced weird errors when we start to complain about objects 7 hours before they expire. This PR introduce separate modes for normal strict validation (that we are transitioning to) and paranoid testing mode.