### PR TITLE
Repository and manifest uri validation

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateParser.java
@@ -92,16 +92,8 @@ public abstract class X509CertificateParser<T extends AbstractX509CertificateWra
         X509CertificateParser<? extends X509GenericCertificate> parser;
         if (X509CertificateUtil.isRouter(certificate)) {
             parser = new X509RouterCertificateParser();
-        } else if (
-                X509CertificateUtil.isCa(certificate) ||
-                X509CertificateUtil.isEe(certificate) ||
-                X509CertificateUtil.isRoot(certificate) ||
-                X509CertificateUtil.isObjectIssuer(certificate)
-        ) {
+        } else  {
             parser = new X509ResourceCertificateParser();
-        } else {
-            result.error("cert.type.unknown");
-            return null;
         }
 
         parser.validateX509Certificate(result, certificate);

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateParser.java
@@ -85,21 +85,28 @@ public abstract class X509CertificateParser<T extends AbstractX509CertificateWra
 
     public static X509GenericCertificate parseCertificate(ValidationResult result, byte[] encoded) {
         final X509Certificate certificate = parseEncoded(encoded, result);
-        if (!result.hasFailureForCurrentLocation()) {
-            if (X509CertificateUtil.isRouter(certificate)) {
-                X509RouterCertificateParser parser = new X509RouterCertificateParser();
-                parser.validateX509Certificate(result, certificate);
-                return parser.getCertificate();
-            } else if (X509CertificateUtil.isCa(certificate) ||
-                    X509CertificateUtil.isEe(certificate) ||
-                    X509CertificateUtil.isRoot(certificate) ||
-                    X509CertificateUtil.isObjectIssuer(certificate)) {
-                final X509ResourceCertificateParser parser = new X509ResourceCertificateParser();
-                parser.validateX509Certificate(result, certificate);
-                return parser.getCertificate();
-            }
+        if (result.hasFailureForCurrentLocation()) {
+            return null;
         }
-        return null;
+
+        X509CertificateParser<? extends X509GenericCertificate> parser;
+        if (X509CertificateUtil.isRouter(certificate)) {
+            parser = new X509RouterCertificateParser();
+        } else if (
+                X509CertificateUtil.isCa(certificate) ||
+                X509CertificateUtil.isEe(certificate) ||
+                X509CertificateUtil.isRoot(certificate) ||
+                X509CertificateUtil.isObjectIssuer(certificate)
+        ) {
+            parser = new X509ResourceCertificateParser();
+        } else {
+            result.error("cert.type.unknown");
+            return null;
+        }
+
+        parser.validateX509Certificate(result, certificate);
+
+        return result.hasFailureForCurrentLocation() ? null : parser.getCertificate();
     }
 
     protected void validatePublicKey() {

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
@@ -30,7 +30,6 @@
 package net.ripe.rpki.commons.crypto.x509cert;
 
 import net.ripe.ipresource.IpResourceSet;
-import net.ripe.ipresource.IpResourceType;
 import net.ripe.rpki.commons.crypto.ValidityPeriod;
 import net.ripe.rpki.commons.crypto.rfc3779.ResourceExtensionEncoder;
 import net.ripe.rpki.commons.crypto.rfc3779.ResourceExtensionParser;

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
@@ -222,7 +222,7 @@ public final class X509CertificateUtil {
             return null;
         }
         for (X509CertificateInformationAccessDescriptor ad : accessDescriptor) {
-            if ((method.equals(ad.getMethod())) && (ad.getLocation().getScheme().equals(scheme))) {
+            if ((method.equals(ad.getMethod())) && (ad.getLocation().getScheme().equalsIgnoreCase(scheme))) {
                 return ad.getLocation();
             }
         }
@@ -260,7 +260,7 @@ public final class X509CertificateUtil {
             return null;
         }
         for (URI uri : crlDistributionPoints) {
-            if (uri != null && "rsync".equals(uri.getScheme())) {
+            if (uri != null && "rsync".equalsIgnoreCase(uri.getScheme())) {
                 return uri;
             }
         }

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -250,12 +250,12 @@ public class X509ResourceCertificateParser extends X509CertificateParser<X509Res
             if (ID_AD_CA_REPOSITORY.equals(descriptor.getAccessMethod())) {
                 hasCaRepositorySia = true;
                 URI location = toUri(descriptor, CERT_SIA_URI_SYNTAX);
-                if (location != null && "rsync".equals(location.getScheme())) {
+                if (location != null && "rsync".equalsIgnoreCase(location.getScheme())) {
                     hasRsyncRepositoryUri = true;
                 }
             } else if (ID_AD_RPKI_MANIFEST.equals(descriptor.getAccessMethod())) {
                 URI location = toUri(descriptor, CERT_SIA_URI_SYNTAX);
-                if (location != null && "rsync".equals(location.getScheme())) {
+                if (location != null && "rsync".equalsIgnoreCase(location.getScheme())) {
                     hasManifestUri = true;
                 }
             }
@@ -273,7 +273,7 @@ public class X509ResourceCertificateParser extends X509CertificateParser<X509Res
         for (AccessDescription descriptor : accessDescriptors) {
             if (ID_AD_SIGNED_OBJECT.equals(descriptor.getAccessMethod())) {
                 URI location = toUri(descriptor, CERT_SIA_URI_SYNTAX);
-                if (location != null && "rsync".equals(location.getScheme())) {
+                if (location != null && "rsync".equalsIgnoreCase(location.getScheme())) {
                     hasSignedObjectUri = true;
                 }
             } else if (ID_AD_RPKI_NOTIFY.equals(descriptor.getAccessMethod())) {

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -241,6 +241,7 @@ public class X509ResourceCertificateParser extends X509CertificateParser<X509Res
         }
     }
 
+    // https://tools.ietf.org/html/rfc6487#section-4.8.8.1
     private void validateSiaForCaCertificate(List<AccessDescription> accessDescriptors) {
         boolean hasCaRepositorySia = false;
         boolean hasRsyncRepositoryUri = false;

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -266,6 +266,7 @@ public class X509ResourceCertificateParser extends X509CertificateParser<X509Res
         result.rejectIfFalse(hasManifestUri, CERT_SIA_MANIFEST_URI_PRESENT);
     }
 
+    // https://tools.ietf.org/html/rfc6487#section-4.8.8.2
     private void validateSiaForEeCertificate(List<AccessDescription> accessDescriptors) {
         Set<String> otherAccessMethods = new TreeSet<>();
         boolean hasSignedObjectUri = false;

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/CertificateElement.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/CertificateElement.java
@@ -91,7 +91,7 @@ public class CertificateElement {
 
     public URI getRsyncAIAPointer() {
         for (URI uri : issuerCertificatePublicationLocationUris) {
-            if (uri.toString().startsWith("rsync")) {
+            if ("rsync".equalsIgnoreCase(uri.getScheme())) {
                 return uri;
             }
         }

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationLocation.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationLocation.java
@@ -31,6 +31,8 @@ package net.ripe.rpki.commons.validation;
 
 
 import org.apache.commons.lang.Validate;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
 
 import java.io.Serializable;
 import java.net.URI;
@@ -57,6 +59,11 @@ public class ValidationLocation implements Serializable, Comparable<ValidationLo
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("name", name).toString();
     }
 
     @Override

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationResult.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationResult.java
@@ -372,5 +372,14 @@ public final class ValidationResult implements Serializable {
         // Average of 12-13 passed checks per location (min = 1, max = 18) as of 2020-07-08 on RIPE NCC trust anchor,
         // we use a slightly higher initial capacity to avoid re-sizing.
         final List<ValidationCheck> passed = new ArrayList<>(20);
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                    .append("error", error)
+                    .append("warning", warning)
+                    .append("passed", passed)
+                    .toString();
+        }
     }
 }

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
@@ -121,6 +121,7 @@ public final class ValidationString {
     public static final String CERT_SIA_CA_REPOSITORY_RSYNC_URI_PRESENT = "cert.sia.ca.repository.rsync.uri.present";
     public static final String CERT_SIA_MANIFEST_URI_PRESENT = "cert.sia.manifest.uri.present";
     public static final String CERT_SIA_SIGNED_OBJECT_URI_PRESENT = "cert.sia.signed.object.uri.present";
+    public static final String CERT_SIA_RRDP_NOTIFY_URI_HTTPS = "cert.sia.rrdp.notify.uri.https";
     public static final String CERT_SIA_EE_CERTIFICATE_OTHER_ACCESS_METHODS = "cert.sia.ee.certificate.other.access.methods";
 
     // router certificate

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
@@ -120,6 +120,7 @@ public final class ValidationString {
     public static final String CERT_SIA_CA_REPOSITORY_URI_PRESENT = "cert.sia.ca.repository.uri.present";
     public static final String CERT_SIA_CA_REPOSITORY_RSYNC_URI_PRESENT = "cert.sia.ca.repository.rsync.uri.present";
     public static final String CERT_SIA_MANIFEST_URI_PRESENT = "cert.sia.manifest.uri.present";
+    public static final String CERT_SIA_SIGNED_OBJECT_URI_PRESENT = "cert.sia.signed.object.uri.present";
 
     // router certificate
     public static final String BGPSEC_EXT_PRESENT = "cert.bgpsec.ext.present";

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
@@ -95,6 +95,7 @@ public final class ValidationString {
     public static final String CRLDP_URI_SYNTAX = "cert.crldp.uri.syntax";
     public static final String CRLDP_RSYNC_URI_PRESENT = "cert.crldp.rsync.uri.present";
     public static final String CRITICAL_EXT_PRESENT = "cert.critical.exts.present";
+    public static final String NON_CRITICAL_EXT_PRESENT = "cert.non.critical.exts.present";
     public static final String POLICY_EXT_CRITICAL = "cert.policy.ext.critical";
     public static final String POLICY_EXT_VALUE = "cert.policy.ext.value";
     public static final String SINGLE_CERT_POLICY = "cert.single.cert.policy";
@@ -111,8 +112,16 @@ public final class ValidationString {
     public static final String CERT_SUBJECT_CORRECT = "cert.subject.correct";
     public static final String CERT_NO_SUBJECT_PK_INFO = "cert.subj.pk.not.present";
 
-    // router certificate
+    // SIA
+    public static final String CERT_SIA_NON_CRITICAL_EXTENSION = "cert.sia.non.critical.extension";
     public static final String CERT_SIA_IS_PRESENT = "cert.sia.present";
+    public static final String CERT_SIA_PARSED = "cert.sia.parsed";
+    public static final String CERT_SIA_URI_SYNTAX = "cert.sia.uri.syntax";
+    public static final String CERT_SIA_CA_REPOSITORY_URI_PRESENT = "cert.sia.ca.repository.uri.present";
+    public static final String CERT_SIA_CA_REPOSITORY_RSYNC_URI_PRESENT = "cert.sia.ca.repository.rsync.uri.present";
+    public static final String CERT_SIA_MANIFEST_URI_PRESENT = "cert.sia.manifest.uri.present";
+
+    // router certificate
     public static final String BGPSEC_EXT_PRESENT = "cert.bgpsec.ext.present";
 
     //cms object

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
@@ -121,6 +121,7 @@ public final class ValidationString {
     public static final String CERT_SIA_CA_REPOSITORY_RSYNC_URI_PRESENT = "cert.sia.ca.repository.rsync.uri.present";
     public static final String CERT_SIA_MANIFEST_URI_PRESENT = "cert.sia.manifest.uri.present";
     public static final String CERT_SIA_SIGNED_OBJECT_URI_PRESENT = "cert.sia.signed.object.uri.present";
+    public static final String CERT_SIA_EE_CERTIFICATE_OTHER_ACCESS_METHODS = "cert.sia.ee.certificate.other.access.methods";
 
     // router certificate
     public static final String BGPSEC_EXT_PRESENT = "cert.bgpsec.ext.present";

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateBottomUpValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateBottomUpValidator.java
@@ -130,16 +130,17 @@ public class X509ResourceCertificateBottomUpValidator implements X509ResourceCer
                 return;
             }
 
+            ValidationLocation parentLocation = new ValidationLocation(parent.getName());
+            result.setLocation(parentLocation);
+
             X509ResourceCertificateParser parser = new X509ResourceCertificateParser();
-            parser.parse(ValidationResult.withLocation(parent.getName()), parent.getContent());
+            parser.parse(result, parent.getContent());
             if (result.hasFailures()) {
                 return;
             }
 
             cert = parser.getCertificate();
-            ValidationLocation parentLocation = new ValidationLocation(parent.getName());
             certificates.add(0, new CertificateWithLocation(cert, parentLocation));
-            result.setLocation(parentLocation);
             if (!result.rejectIfFalse(certificates.size() <= MAX_CHAIN_LENGTH, CERT_CHAIN_LENGTH, Integer.valueOf(MAX_CHAIN_LENGTH).toString())) {
                 return;
             }

--- a/src/main/resources/validation_en.properties
+++ b/src/main/resources/validation_en.properties
@@ -313,6 +313,10 @@ cert.sia.signed.object.uri.present.passed=Signed object URI is present
 cert.sia.signed.object.uri.present.warning=Signed object URI is missing
 cert.sia.signed.object.uri.present.error=Signed object URI is missing
 
+cert.sia.rrdp.notify.uri.https.passed=RRDP notify URI {0} is HTTPS
+cert.sia.rrdp.notify.uri.https.warning=RRDP notify URI {0} is not HTTPS
+cert.sia.rrdp.notify.uri.https.error=RRDP notify URI {0} is not HTTPS
+
 cert.sia.ee.certificate.other.access.methods.passed=EE certificate SIA does not use other access methods
 cert.sia.ee.certificate.other.access.methods.warning=EE certificate SIA uses other access methods: {0}
 cert.sia.ee.certificate.other.access.methods.error=EE certificate SIA uses other access methods: {0}

--- a/src/main/resources/validation_en.properties
+++ b/src/main/resources/validation_en.properties
@@ -225,6 +225,10 @@ cert.critical.exts.present.passed=Critical extensions are present
 cert.critical.exts.present.warning=Critical extensions are missing
 cert.critical.exts.present.error=Critical extensions are missing
 
+cert.non.critical.exts.present.passed=Non-critical extensions are present
+cert.non.critical.exts.present.warning=Non-critical extensions are missing
+cert.non.critical.exts.present.error=Non-critical extensions are missing
+
 cert.policy.ext.critical.passed=Critical extension IDs contain policy extension ID
 cert.policy.ext.critical.warning=Critical extension IDs do not contain policy extension ID
 cert.policy.ext.critical.error=Critical extension IDs do not contain policy extension ID
@@ -277,9 +281,33 @@ cert.subj.pk.not.present.passed=subjectPublicKeyInfo is present
 cert.subj.pk.not.present.warning=subjectPublicKeyInfo is missing
 cert.subj.pk.not.present.error=subjectPublicKeyInfo is missing
 
+cert.sia.non.critical.extension.passed=Non-critical extension IDs contain subject information access ID
+cert.sia.non.critical.extension.warning=Non-critical extension IDs do not contain subject information access ID
+cert.sia.non.critical.extension.error=Non-critical extension IDs do not contain subject information access ID
+
 cert.sia.present.passed=Subject Information Access is present
 cert.sia.present.warning=Subject Information Access is missing
 cert.sia.present.error=Subject Information Access is missing
+
+cert.sia.parsed.passed=Subject Information Access can be parsed
+cert.sia.parsed.warning=Subject Information Access cannot be parsed
+cert.sia.parsed.error=Subject Information Access cannot be parsed
+
+cert.sia.uri.syntax.passed=Subject Information Access location is a valid URI
+cert.sia.uri.syntax.warning=Subject Information Access location is not a valid URI
+cert.sia.uri.syntax.error=Subject Information Access location is not a valid URI
+
+cert.sia.ca.repository.uri.present.passed=CA repository URI is present
+cert.sia.ca.repository.uri.present.warning=CA repository URI is missing
+cert.sia.ca.repository.uri.present.error=CA repository URI is missing
+
+cert.sia.ca.repository.rsync.uri.present.passed=CA repository rsync URI is present
+cert.sia.ca.repository.rsync.uri.present.warning=CA repository rsync URI is missing
+cert.sia.ca.repository.rsync.uri.present.error=CA repository rsync URI is missing
+
+cert.sia.manifest.uri.present.passed=Manifest URI is present
+cert.sia.manifest.uri.present.warning=Manifest URI is missing
+cert.sia.manifest.uri.present.error=Manifest URI is missing
 
 cert.bgpsec.ext.present.passed=BGPsec Router EKU is present
 cert.bgpsec.ext.present.warning=BGPsec Router EKU is missing

--- a/src/main/resources/validation_en.properties
+++ b/src/main/resources/validation_en.properties
@@ -309,6 +309,10 @@ cert.sia.manifest.uri.present.passed=Manifest URI is present
 cert.sia.manifest.uri.present.warning=Manifest URI is missing
 cert.sia.manifest.uri.present.error=Manifest URI is missing
 
+cert.sia.signed.object.uri.present.passed=Signed object URI is present
+cert.sia.signed.object.uri.present.warning=Signed object URI is missing
+cert.sia.signed.object.uri.present.error=Signed object URI is missing
+
 cert.bgpsec.ext.present.passed=BGPsec Router EKU is present
 cert.bgpsec.ext.present.warning=BGPsec Router EKU is missing
 cert.bgpsec.ext.present.error=BGPsec Router EKU is missing

--- a/src/main/resources/validation_en.properties
+++ b/src/main/resources/validation_en.properties
@@ -313,6 +313,10 @@ cert.sia.signed.object.uri.present.passed=Signed object URI is present
 cert.sia.signed.object.uri.present.warning=Signed object URI is missing
 cert.sia.signed.object.uri.present.error=Signed object URI is missing
 
+cert.sia.ee.certificate.other.access.methods.passed=EE certificate SIA does not use other access methods
+cert.sia.ee.certificate.other.access.methods.warning=EE certificate SIA uses other access methods: {0}
+cert.sia.ee.certificate.other.access.methods.error=EE certificate SIA uses other access methods: {0}
+
 cert.bgpsec.ext.present.passed=BGPsec Router EKU is present
 cert.bgpsec.ext.present.warning=BGPsec Router EKU is missing
 cert.bgpsec.ext.present.error=BGPsec Router EKU is missing

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParserTest.java
@@ -33,6 +33,7 @@ import net.ripe.ipresource.IpResourceSet;
 import net.ripe.ipresource.IpResourceType;
 import net.ripe.rpki.commons.crypto.ValidityPeriod;
 import net.ripe.rpki.commons.crypto.util.KeyPairFactoryTest;
+import net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor;
 import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificate;
 import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificateBuilder;
 import org.bouncycastle.asn1.BERTags;
@@ -45,6 +46,7 @@ import org.junit.Test;
 
 import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
+import java.net.URI;
 import java.security.KeyPair;
 import java.util.EnumSet;
 import java.util.Map;
@@ -52,6 +54,7 @@ import java.util.TreeMap;
 
 import static net.ripe.rpki.commons.crypto.util.Asn1Util.*;
 import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper.*;
+import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor.ID_AD_SIGNED_OBJECT;
 import static org.junit.Assert.*;
 
 
@@ -132,6 +135,9 @@ public class ManifestCmsParserTest {
         builder.withResources(new IpResourceSet());
         builder.withInheritedResourceTypes(EnumSet.allOf(IpResourceType.class));
         builder.withValidityPeriod(new ValidityPeriod(THIS_UPDATE_TIME, NEXT_UPDATE_TIME));
+        builder.withSubjectInformationAccess(
+                new X509CertificateInformationAccessDescriptor(ID_AD_SIGNED_OBJECT, URI.create("rsync://example.com/repository/manifest.mft"))
+        );
         return builder.build();
     }
 

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -72,6 +72,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper.*;
+import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor.ID_AD_SIGNED_OBJECT;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -441,6 +442,9 @@ public class ManifestCmsTest {
         builder.withInheritedResourceTypes(EnumSet.allOf(IpResourceType.class));
         builder.withValidityPeriod(new ValidityPeriod(MFT_EE_NOT_BEFORE, MFT_EE_NOT_AFTER));
         builder.withCrlDistributionPoints(ROOT_MANIFEST_CRL_LOCATION);
+        builder.withSubjectInformationAccess(
+                new X509CertificateInformationAccessDescriptor(ID_AD_SIGNED_OBJECT, ROOT_SIA_MANIFEST_RSYNC_LOCATION)
+        );
         return builder;
     }
 

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
@@ -110,7 +110,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof RoaCms);
         assertEquals(roaCms, object);
-        assertEquals(52, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(53, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertFalse(validationResult.hasFailures());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
         assertEquals(ValidationStatus.WARNING, validationResult.getResultForCurrentLocation(CRLDP_OMITTED).getStatus());
@@ -139,7 +139,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof ManifestCms);
         assertEquals(manifestCms, object);
-        assertEquals(55, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(56, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertTrue(validationResult.hasNoFailuresOrWarnings());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
@@ -82,7 +82,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof X509ResourceCertificate);
         assertEquals(cert, object);
-        assertEquals(16, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(25, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertTrue(validationResult.hasNoFailuresOrWarnings());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
         assertTrue(validationResult.getResultForCurrentLocation(CERTIFICATE_PARSED).isOk());
@@ -110,7 +110,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof RoaCms);
         assertEquals(roaCms, object);
-        assertEquals(46, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(48, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertFalse(validationResult.hasFailures());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
         assertEquals(ValidationStatus.WARNING, validationResult.getResultForCurrentLocation(CRLDP_OMITTED).getStatus());
@@ -139,7 +139,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof ManifestCms);
         assertEquals(manifestCms, object);
-        assertEquals(48, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(51, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertTrue(validationResult.hasNoFailuresOrWarnings());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
@@ -80,9 +80,10 @@ public class CertificateRepositoryObjectFactoryTest {
 
         CertificateRepositoryObject object = createCertificateRepositoryObject(cert.getEncoded(), validationResult);
 
+        assertFalse("no validation failures " + validationResult.getFailuresForCurrentLocation(), validationResult.hasFailureForCurrentLocation());
         assertTrue(object instanceof X509ResourceCertificate);
         assertEquals(cert, object);
-        assertEquals(25, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(27, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertTrue(validationResult.hasNoFailuresOrWarnings());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
         assertTrue(validationResult.getResultForCurrentLocation(CERTIFICATE_PARSED).isOk());

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
@@ -110,7 +110,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof RoaCms);
         assertEquals(roaCms, object);
-        assertEquals(48, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(52, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertFalse(validationResult.hasFailures());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
         assertEquals(ValidationStatus.WARNING, validationResult.getResultForCurrentLocation(CRLDP_OMITTED).getStatus());
@@ -139,7 +139,7 @@ public class CertificateRepositoryObjectFactoryTest {
 
         assertTrue(object instanceof ManifestCms);
         assertEquals(manifestCms, object);
-        assertEquals(51, validationResult.getAllValidationChecksForCurrentLocation().size());
+        assertEquals(55, validationResult.getAllValidationChecksForCurrentLocation().size());
         assertTrue(validationResult.hasNoFailuresOrWarnings());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateTest.java
@@ -74,9 +74,10 @@ public class X509ResourceCertificateTest {
     public static final URI TEST_CA_URI = URI.create("rsync://host.foo/ca.cer");
     private static final ValidationLocation CERT_URI_VALIDATION_LOCATION = new ValidationLocation(TEST_TA_URI);
 
-    public static final URI TEST_TA_CRL = URI.create("rsync://host.foo/bar/ta.crl");
-    private static final URI MFT_URI = URI.create("rsync://host.foo/bar/ta.mft");
-    private static final URI PUB_DIR_URI = URI.create("rsync://host.foo/bar/");
+    public static final URI TEST_TA_CRL = URI.create("Rsync://host.foo/bar/ta.crl");
+    private static final URI MFT_URI = URI.create("Rsync://host.foo/bar/ta.mft");
+    private static final URI PUB_DIR_URI = URI.create("RSYNC://host.foo/bar/");
+    private static final URI PUB_NOTIFY_URI = URI.create("HTTP://host.foo/notify.xml");
 
 
     private static final ValidationLocation CRL_DP_VALIDATION_LOCATION = new ValidationLocation(TEST_TA_CRL);
@@ -114,7 +115,9 @@ public class X509ResourceCertificateTest {
 
         X509CertificateInformationAccessDescriptor[] descriptors = {
                 new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_CA_REPOSITORY, PUB_DIR_URI),
-                new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_RPKI_MANIFEST, MFT_URI)};
+                new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_RPKI_NOTIFY, PUB_NOTIFY_URI),
+                new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_RPKI_MANIFEST, MFT_URI)
+        };
         builder.withSubjectInformationAccess(descriptors);
 
         return builder;
@@ -234,13 +237,14 @@ public class X509ResourceCertificateTest {
     public void shouldSupportSubjectInformationAccessExtension() throws URISyntaxException {
         X509CertificateInformationAccessDescriptor[] descriptors = {
                 new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_CA_REPOSITORY, new URI("rsync://foo.host/bar/")),
-                new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_CA_REPOSITORY, new URI("http://foo.host/bar/"))
+                new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_RPKI_NOTIFY, new URI("HTTPS://foo.host/notify.xml"))
         };
         X509ResourceCertificateBuilder builder = createSelfSignedEeCertificateBuilder();
         builder.withSubjectInformationAccess(descriptors);
         X509ResourceCertificate cert = builder.build();
         assertArrayEquals(descriptors, cert.getSubjectInformationAccess());
         assertNotNull(cert.findFirstSubjectInformationAccessByMethod(X509CertificateInformationAccessDescriptor.ID_AD_CA_REPOSITORY));
+        assertEquals(URI.create("https://foo.host/notify.xml"), cert.getRrdpNotifyUri());
     }
 
     @Test

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateTest.java
@@ -77,7 +77,7 @@ public class X509ResourceCertificateTest {
     public static final URI TEST_TA_CRL = URI.create("Rsync://host.foo/bar/ta.crl");
     private static final URI MFT_URI = URI.create("Rsync://host.foo/bar/ta.mft");
     private static final URI PUB_DIR_URI = URI.create("RSYNC://host.foo/bar/");
-    private static final URI PUB_NOTIFY_URI = URI.create("HTTP://host.foo/notify.xml");
+    private static final URI PUB_NOTIFY_URI = URI.create("HTTPS://host.foo/notify.xml");
 
 
     private static final ValidationLocation CRL_DP_VALIDATION_LOCATION = new ValidationLocation(TEST_TA_CRL);

--- a/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateBottomUpValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateBottomUpValidatorTest.java
@@ -36,6 +36,7 @@ import net.ripe.rpki.commons.crypto.ValidityPeriod;
 import net.ripe.rpki.commons.crypto.crl.X509Crl;
 import net.ripe.rpki.commons.crypto.crl.X509CrlBuilder;
 import net.ripe.rpki.commons.crypto.util.PregeneratedKeyPairFactory;
+import net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor;
 import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificate;
 import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificateBuilder;
 import net.ripe.rpki.commons.util.UTC;
@@ -54,6 +55,8 @@ import java.security.cert.CRLException;
 import java.util.EnumSet;
 
 import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper.*;
+import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor.ID_AD_CA_REPOSITORY;
+import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor.ID_AD_RPKI_MANIFEST;
 import static org.junit.Assert.*;
 
 
@@ -167,6 +170,7 @@ public class X509ResourceCertificateBottomUpValidatorTest {
 
         X509ResourceCertificateBottomUpValidator validator = new X509ResourceCertificateBottomUpValidator(new ResourceCertificateLocatorImpl());
         validator.validate("child", child);
+        System.out.println(validator.getValidationResult());
         assertTrue(validator.getValidationResult().hasFailures());
         assertTrue(validator.getValidationResult().hasFailureForLocation(CHILD_VALIDATION_LOCATION));
         assertTrue(ValidationString.PREV_SUBJECT_EQ_ISSUER.equals(validator.getValidationResult().getFailures(CHILD_VALIDATION_LOCATION).get(0).getKey()));
@@ -247,6 +251,10 @@ public class X509ResourceCertificateBottomUpValidatorTest {
         builder.withSubjectKeyIdentifier(true);
         builder.withResources(ROOT_RESOURCE_SET);
         builder.withAuthorityKeyIdentifier(false);
+        builder.withSubjectInformationAccess(
+            new X509CertificateInformationAccessDescriptor(ID_AD_CA_REPOSITORY, URI.create("rsync://example.com/root")),
+            new X509CertificateInformationAccessDescriptor(ID_AD_RPKI_MANIFEST, URI.create("rsync://example.com/root/manifest.mft"))
+        );
         builder.withSigningKeyPair(ROOT_KEY_PAIR);
         return builder.build();
     }
@@ -267,6 +275,10 @@ public class X509ResourceCertificateBottomUpValidatorTest {
         builder.withInheritedResourceTypes(EnumSet.allOf(IpResourceType.class));
         builder.withValidityPeriod(VALIDITY_PERIOD);
         builder.withCrlDistributionPoints(URI.create("rsync://localhost/ta.crl"));
+        builder.withSubjectInformationAccess(
+                new X509CertificateInformationAccessDescriptor(ID_AD_CA_REPOSITORY, URI.create("rsync://example.com/repository")),
+                new X509CertificateInformationAccessDescriptor(ID_AD_RPKI_MANIFEST, URI.create("rsync://example.com/repository/manifest.mft"))
+        );
         return builder;
     }
 


### PR DESCRIPTION
Performs Subject Information Access (SIA) validations as specified by [RFC6487 section 4.8.8](https://tools.ietf.org/html/rfc6487#section-4.8.8).

Only generates a warning for EE certificates with a SIA rpkiNotify access methods since AFRINIC manifests contain this, even though it doesn't seem to be allowed by the RFC.