### PR TITLE
Stricter checking of certificate Subject and Issuer DN

### DIFF
--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
@@ -141,7 +141,7 @@ public class CertificateRepositoryObjectFactoryTest {
         assertTrue(object instanceof ManifestCms);
         assertEquals(manifestCms, object);
         assertEquals(56, validationResult.getAllValidationChecksForCurrentLocation().size());
-        assertTrue(validationResult.hasNoFailuresOrWarnings());
+        assertTrue("" + validationResult.getAllValidationChecksForCurrentLocation(), validationResult.hasNoFailuresOrWarnings());
         assertTrue(validationResult.getResultForCurrentLocation(KNOWN_OBJECT_TYPE).isOk());
     }
 

--- a/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateBottomUpValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateBottomUpValidatorTest.java
@@ -62,14 +62,14 @@ import static org.junit.Assert.*;
 
 public class X509ResourceCertificateBottomUpValidatorTest {
 
-    private static final X500Principal ROOT_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only, CN=RIPE NCC, C=NL");
+    private static final X500Principal ROOT_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only - RIPE NCC - NL");
     private static final IpResourceSet ROOT_RESOURCE_SET = IpResourceSet.parse("10.0.0.0/8, 192.168.0.0/16, ffce::/16, AS21212");
     private static final BigInteger ROOT_SERIAL_NUMBER = BigInteger.valueOf(900);
     private static final ValidityPeriod VALIDITY_PERIOD = new ValidityPeriod(UTC.dateTime().minusMinutes(1), UTC.dateTime().plusYears(1));
 
-    private static final X500Principal FIRST_CHILD_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only, CN=First Child, C=NL");
+    private static final X500Principal FIRST_CHILD_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only - First Child - NL");
     private static final BigInteger FIRST_CHILD_SERIAL_NUMBER = ROOT_SERIAL_NUMBER.add(BigInteger.valueOf(1));
-    private static final X500Principal SECOND_CHILD_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only, CN=Second Child, C=NL");
+    private static final X500Principal SECOND_CHILD_CERTIFICATE_NAME = new X500Principal("CN=For Testing Only - Second Child - NL");
     private static final BigInteger SECOND_CHILD_SERIAL_NUMBER = FIRST_CHILD_SERIAL_NUMBER.add(BigInteger.valueOf(1));
     private static final IpResourceSet CHILD_RESOURCE_SET = IpResourceSet.parse("10.0.0.0/8, 192.168.0.0/17, ffce::/16, AS21212");
     private static final IpResourceSet INVALID_CHILD_RESOURCE_SET = IpResourceSet.parse("10.0.0.0/8, 192.168.0.0/15, ffce::/16, AS21212");


### PR DESCRIPTION
Matches RFC6487 section 4.4 and 4.5 now, except that we also accept UTF-8 strings.

Now we no longer warn about the "The issuer CN=e6c7f8d7-4c06-4480-bbd8-71cf97b216b6 does not have the correct format." from the APNIC TA. 