### PR TITLE
Validate manifest entry file name

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -331,7 +331,13 @@ public class X509ResourceCertificateParser extends X509CertificateParser<X509Res
         try {
             URI uri = new URI(uriString);
             URI normalized = uri.normalize();
-            result.warnIfFalse(uri.equals(normalized), key, uriString);
+            if (uri.isOpaque() || !uri.isAbsolute() || uri.getHost() == null) {
+                result.error(key, uriString);
+            } else if (!uri.equals(normalized)) {
+                result.warn(key, uriString);
+            } else {
+                result.pass(key, uriString);
+            }
             return normalized;
         } catch (URISyntaxException e) {
             result.error(key, uriString);

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
@@ -189,6 +189,7 @@ public final class ValidationString {
     public static final String MANIFEST_BEFORE_THIS_UPDATE_TIME = "mf.before.this.update";
     public static final String MANIFEST_PAST_NEXT_UPDATE_TIME = "mf.past.next.update";
     public static final String MANIFEST_THIS_UPDATE_TIME_BEFORE_NEXT_UPDATE_TIME = "mf.this.update.before.next.update";
+    public static final String MANIFEST_ENTRY_FILE_NAME_IS_RELATIVE = "mf.entry.file.name.is.relative";
 
     //ghostbusters
     public static final String GHOSTBUSTERS_RECORD_CONTENT_TYPE = "ghostbusters.record.content.type";

--- a/src/main/resources/validation_en.properties
+++ b/src/main/resources/validation_en.properties
@@ -568,6 +568,10 @@ mf.this.update.before.next.update.passed=Manifest this update time ({0}) is befo
 mf.this.update.before.next.update.warning=Manifest this update time ({0}) is after next update time ({0})
 mf.this.update.before.next.update.error=Manifest this update time ({0}) is after next update time ({0})
 
+mf.entry.file.name.is.relative.passed=All manifest entry file names are relative
+mf.entry.file.name.is.relative.warning=Some manifest entry file names are not relative ({0})
+mf.entry.file.name.is.relative.error=Some manifest entry file names are not relative ({0})
+
 validator.uri.safety.passed=URI ''{0}'' does not contain unsafe character sequences
 validator.uri.safety.warning=URI ''{0}'' contains unsafe character sequences
 validator.uri.safety.error=URI ''{0}'' contains unsafe character sequences

--- a/src/main/resources/validation_en.properties
+++ b/src/main/resources/validation_en.properties
@@ -214,7 +214,7 @@ cert.crldp.name.is.a.uri.warning=CRL Distribution Point name is not a uniformRes
 cert.crldp.name.is.a.uri.error=CRL Distribution Point name is not a uniformResourceIdentifier
 
 cert.crldp.uri.syntax.passed=CRL Distribution Point is a valid URI
-cert.crldp.uri.syntax.warning=CRL Distribution Point is not a valid URI
+cert.crldp.uri.syntax.warning=CRL Distribution Point is not a normalized URI
 cert.crldp.uri.syntax.error=CRL Distribution Point is not a valid URI
 
 cert.crldp.rsync.uri.present.passed=CRL Distribution Point rsync URI present
@@ -294,7 +294,7 @@ cert.sia.parsed.warning=Subject Information Access cannot be parsed
 cert.sia.parsed.error=Subject Information Access cannot be parsed
 
 cert.sia.uri.syntax.passed=Subject Information Access location is a valid URI
-cert.sia.uri.syntax.warning=Subject Information Access location is not a valid URI
+cert.sia.uri.syntax.warning=Subject Information Access location is not a normalized URI
 cert.sia.uri.syntax.error=Subject Information Access location is not a valid URI
 
 cert.sia.ca.repository.uri.present.passed=CA repository URI is present

--- a/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateBottomUpValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateBottomUpValidatorTest.java
@@ -138,6 +138,7 @@ public class X509ResourceCertificateBottomUpValidatorTest {
         validator.validate("grandchild", grandchild);
         assertTrue(validator.getValidationResult().hasFailures());
 
+        System.out.println(validator.getValidationResult().getFailuresForAllLocations());
         assertTrue(validator.getValidationResult().hasFailureForLocation(GRAND_CHILD_VALIDATION_LOCATION));
         assertTrue(ValidationString.RESOURCE_RANGE.equals(validator.getValidationResult().getFailures(GRAND_CHILD_VALIDATION_LOCATION).get(0).getKey()));
     }
@@ -252,7 +253,7 @@ public class X509ResourceCertificateBottomUpValidatorTest {
         builder.withResources(ROOT_RESOURCE_SET);
         builder.withAuthorityKeyIdentifier(false);
         builder.withSubjectInformationAccess(
-            new X509CertificateInformationAccessDescriptor(ID_AD_CA_REPOSITORY, URI.create("rsync://example.com/root")),
+            new X509CertificateInformationAccessDescriptor(ID_AD_CA_REPOSITORY, URI.create("rsync://example.com/root/")),
             new X509CertificateInformationAccessDescriptor(ID_AD_RPKI_MANIFEST, URI.create("rsync://example.com/root/manifest.mft"))
         );
         builder.withSigningKeyPair(ROOT_KEY_PAIR);
@@ -276,7 +277,7 @@ public class X509ResourceCertificateBottomUpValidatorTest {
         builder.withValidityPeriod(VALIDITY_PERIOD);
         builder.withCrlDistributionPoints(URI.create("rsync://localhost/ta.crl"));
         builder.withSubjectInformationAccess(
-                new X509CertificateInformationAccessDescriptor(ID_AD_CA_REPOSITORY, URI.create("rsync://example.com/repository")),
+                new X509CertificateInformationAccessDescriptor(ID_AD_CA_REPOSITORY, URI.create("rsync://example.com/repository/")),
                 new X509CertificateInformationAccessDescriptor(ID_AD_RPKI_MANIFEST, URI.create("rsync://example.com/repository/manifest.mft"))
         );
         return builder;


### PR DESCRIPTION
Only allow normal characters in manifest entry file names. RFC 6486 is
actually not clear what is allowed and simply requires that manifest
entries are published in the same repository as the manifest. Quote
from the RFC: "the name of the file in the repository publication
point (directory)".

We allow the characters from `DERPrintableString#isPrintableString`
except for slash (directory separator). We also allow the
underscore (`_`) since it is used by some certificate authorities
already.

Also ensure the rsync repository URI ends with a slash, so that manifest
entries resolve correctly using the `URI#resolve` method.

Finally, URIs should not be opaque (without path) and have at least the
hostname specified.