### PR TITLE
Upgrade to bouncy castle 1.67

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <net.ripe.ipresource.version>1.46</net.ripe.ipresource.version>
-        <bouncycastle.version>1.66</bouncycastle.version>
+        <bouncycastle.version>1.67</bouncycastle.version>
         <guava.version>28.2-jre</guava.version>
         <joda-time.version>2.10.5</joda-time.version>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/Asn1Util.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/Asn1Util.java
@@ -36,12 +36,7 @@ import net.ripe.ipresource.IpResourceType;
 import net.ripe.ipresource.UniqueIpResource;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.Validate;
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1Integer;
-import org.bouncycastle.asn1.ASN1Primitive;
-import org.bouncycastle.asn1.DERBitString;
-import org.bouncycastle.asn1.DEROutputStream;
+import org.bouncycastle.asn1.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -57,7 +52,7 @@ public final class Asn1Util {
     public static byte[] encode(ASN1Encodable value) {
         try {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            DEROutputStream derOutputStream = new DEROutputStream(byteArrayOutputStream);
+            ASN1OutputStream derOutputStream = ASN1OutputStream.create(byteArrayOutputStream, ASN1Encoding.DER);
             derOutputStream.writeObject(value);
             derOutputStream.close();
             return byteArrayOutputStream.toByteArray();


### PR DESCRIPTION
DEROutputStream was deprecated and replaced by ASN1OutputStream per
the recommendation [0].

[0]: https://github.com/bcgit/bc-java/blob/07604208a773d2334fb09276796288404804e557/core/src/main/java/org/bouncycastle/asn1/DEROutputStream.java#L15