### PR TITLE
ResourceCertificateRequest: optionally have an IPResourceSet

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/ta/domain/request/ResourceCertificateRequestData.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/request/ResourceCertificateRequestData.java
@@ -45,20 +45,35 @@ public class ResourceCertificateRequestData extends EqualsSupport implements Ser
     private final String resourceClassName;
     private final X500Principal subjectDN;
     private final X509CertificateInformationAccessDescriptor[] subjectInformationAccess;
+    private final IpResourceSet ipResourceSet;
     private final byte[] encodedSubjectPublicKey;
 
+    public static ResourceCertificateRequestData forTASigningRequest(
+            String resourceClassName,
+            X500Principal subjectDN,
+            byte[] encodedSubjectPublicKey,
+            X509CertificateInformationAccessDescriptor[] subjectInformationAccess
+    ) {
+        return new ResourceCertificateRequestData(resourceClassName, subjectDN, encodedSubjectPublicKey, subjectInformationAccess, null);
+    }
 
-    public ResourceCertificateRequestData(String resourceClassName, X500Principal subjectDN, PublicKey subjectPublicKey,
-                                          X509CertificateInformationAccessDescriptor[] subjectInformationAccess, IpResourceSet ipResourceSet) {
-        this(resourceClassName, subjectDN, subjectPublicKey.getEncoded(), subjectInformationAccess);
+    public static ResourceCertificateRequestData forUpstreamCARequest(
+            String resourceClassName,
+            X500Principal subjectDN,
+            PublicKey subjectPublicKey,
+            X509CertificateInformationAccessDescriptor[] subjectInformationAccess,
+            IpResourceSet ipResourceSet
+    ) {
+        return new ResourceCertificateRequestData(resourceClassName, subjectDN, subjectPublicKey.getEncoded(), subjectInformationAccess, ipResourceSet);
     }
 
     public ResourceCertificateRequestData(String resourceClassName, X500Principal subjectDN, byte[] encodedSubjectPublicKey,
-                                          X509CertificateInformationAccessDescriptor[] subjectInformationAccess) {
+                                          X509CertificateInformationAccessDescriptor[] subjectInformationAccess, IpResourceSet ipResourceSet) {
         this.resourceClassName = resourceClassName;
         this.subjectDN = subjectDN;
         this.encodedSubjectPublicKey = encodedSubjectPublicKey;
         this.subjectInformationAccess = subjectInformationAccess;
+        this.ipResourceSet = ipResourceSet;
     }
 
     public String getResourceClassName() {
@@ -75,5 +90,9 @@ public class ResourceCertificateRequestData extends EqualsSupport implements Ser
 
     public X509CertificateInformationAccessDescriptor[] getSubjectInformationAccess() {
         return subjectInformationAccess;
+    }
+
+    public IpResourceSet getIpResourceSet() {
+        return ipResourceSet;
     }
 }

--- a/src/main/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorRequestSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorRequestSerializer.java
@@ -274,7 +274,9 @@ public class TrustAnchorRequestSerializer extends DomXmlSerializer<TrustAnchorRe
 
             final X509CertificateInformationAccessDescriptor[] x509CertificateInformationAccessDescriptors = getX509CertificateInformationAccessDescriptorArray(subjectInformationAccessElement);
 
-            final TaRequest taRequest = new SigningRequest(new ResourceCertificateRequestData(resourceClassName, subjectDN, subjectPublicKey, x509CertificateInformationAccessDescriptors));
+            final TaRequest taRequest = new SigningRequest(
+                    ResourceCertificateRequestData.forTASigningRequest(resourceClassName, subjectDN, subjectPublicKey, x509CertificateInformationAccessDescriptors)
+            );
 
             final Element requestIdElement = getSingleChildElement(signingRequestElement, REQUEST_ID);
             final String requestId = getElementTextContent(requestIdElement);


### PR DESCRIPTION
Upstream CA requests include IP resources. While not used directly, they must be
stored in the object graph for lossless deserialization/serialization.

Because the TA signing requests don't contain IP resources and no expose the
`null` field too much, provide separate factory functions for these cases.