### PR TITLE
Check public key algorithm to be RSA

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
@@ -314,6 +314,7 @@ public final class X509CertificateBuilderHelper {
         Validate.notNull(publicKey, "no publicKey");
         Validate.notNull(signingKeyPair, "no signingKeyPair");
         Validate.notNull(validityPeriod, "no validityPeriod");
+        Validate.isTrue("RSA".equals(publicKey.getAlgorithm()), "publicKey algorithm is not RSA");
         if (!ca) {
             Validate.isTrue((keyUsage & KeyUsage.keyCertSign) == 0,
                     "keyCertSign only allowed for ca");

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateBuilderTest.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
 import java.net.URI;
-import java.security.PublicKey;
 
 import static net.ripe.rpki.commons.crypto.util.KeyPairFactoryTest.*;
 import static org.junit.Assert.*;
@@ -62,37 +61,6 @@ public class X509ResourceCertificateBuilderTest {
         DateTime now = UTC.dateTime();
         subject.withValidityPeriod(new ValidityPeriod(now, new DateTime(now.getYear() + 1, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC)));
         subject.withResources(IpResourceSet.ALL_PRIVATE_USE_RESOURCES);
-    }
-
-    @Test
-    public void shouldUseOnlyTheEncodedFormOfThePublicKey() {
-        PublicKey publicKey = new PublicKey() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public String getFormat() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public byte[] getEncoded() {
-                return TEST_KEY_PAIR.getPublic().getEncoded();
-            }
-
-            @Override
-            public String getAlgorithm() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-                throw new UnsupportedOperationException();
-            }
-        };
-
-        subject.withPublicKey(publicKey);
-
-        subject.build();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -220,4 +188,3 @@ public class X509ResourceCertificateBuilderTest {
 
 
 }
-

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateBuilderTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
 import java.net.URI;
-import java.security.PublicKey;
 
 import static net.ripe.rpki.commons.crypto.util.KeyPairFactoryTest.SECOND_TEST_KEY_PAIR;
 import static net.ripe.rpki.commons.crypto.util.KeyPairFactoryTest.TEST_KEY_PAIR;
@@ -64,37 +63,6 @@ public class X509RouterCertificateBuilderTest {
         DateTime now = UTC.dateTime();
         subject.withValidityPeriod(new ValidityPeriod(now, new DateTime(now.getYear() + 1, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC)));
         subject.withAsns(new int[]{1, 2, 3, 4, 5});
-    }
-
-    @Test
-    public void shouldUseOnlyTheEncodedFormOfThePublicKey() {
-        PublicKey publicKey = new PublicKey() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public String getFormat() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public byte[] getEncoded() {
-                return TEST_KEY_PAIR.getPublic().getEncoded();
-            }
-
-            @Override
-            public String getAlgorithm() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-                throw new UnsupportedOperationException();
-            }
-        };
-
-        subject.withPublicKey(publicKey);
-
-        subject.build();
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Drop two tests that try to prevent use of public key information with no obvious
reason not to.