### PR TITLE
Check issuer serial number boundaries

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
@@ -85,6 +85,8 @@ public final class X509CertificateBuilderHelper {
 
     public static final String DEFAULT_SIGNATURE_PROVIDER = "SunRsaSign";
 
+    private static final BigInteger MAX_20_OCTETS = BigInteger.ONE.shiftLeft(160).subtract(BigInteger.ONE);
+
     private String signatureProvider = DEFAULT_SIGNATURE_PROVIDER;
 
     private String signatureAlgorithm = DEFAULT_SIGNATURE_ALGORITHM;
@@ -341,6 +343,10 @@ public final class X509CertificateBuilderHelper {
         Validate.notNull(issuerDN, "no issuerDN");
         Validate.notNull(subjectDN, "no subjectDN");
         Validate.notNull(serial, "no serial");
+        Validate.isTrue(
+                serial.compareTo(BigInteger.ZERO) >= 0 && serial.compareTo(MAX_20_OCTETS) <= 0,
+                "serial number not in (0..MAX)"
+        );
         Validate.notNull(publicKey, "no publicKey");
         Validate.notNull(signingKeyPair, "no signingKeyPair");
         Validate.notNull(validityPeriod, "no validityPeriod");

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
@@ -344,7 +344,7 @@ public final class X509CertificateBuilderHelper {
         Validate.notNull(subjectDN, "no subjectDN");
         Validate.notNull(serial, "no serial");
         Validate.isTrue(
-                serial.compareTo(BigInteger.ZERO) >= 0 && serial.compareTo(MAX_20_OCTETS) <= 0,
+                serial.compareTo(BigInteger.ZERO) > 0 && serial.compareTo(MAX_20_OCTETS) <= 0,
                 "serial number not in (0..MAX)"
         );
         Validate.notNull(publicKey, "no publicKey");

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelperTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelperTest.java
@@ -117,6 +117,12 @@ public class X509CertificateBuilderHelperTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnNeutralIntegerSerial() {
+        subject.withSerial(BigInteger.ZERO);
+        subject.generateCertificate();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void shouldFailOnTooLargeSerial() {
         subject.withSerial(BigInteger.ONE.shiftLeft(160));
         subject.generateCertificate();

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelperTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelperTest.java
@@ -109,4 +109,16 @@ public class X509CertificateBuilderHelperTest {
         // And further attempts to set it are rejected (e.g. in an subtype).
         subject.withPolicies(CAB_BASELINE_REQUIREMENTS_POLICY);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnNegativeSerial() {
+        subject.withSerial(BigInteger.ONE.negate());
+        subject.generateCertificate();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnTooLargeSerial() {
+        subject.withSerial(BigInteger.ONE.shiftLeft(160));
+        subject.generateCertificate();
+    }
 }


### PR DESCRIPTION
RFC 5280 specifies that serial number MUST be a possitive integer and that
conforming CAs MUST NOT use serial numbers longer than 20 octets.