### PR TITLE
Dependency check maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.3.0</version>
+                <version>6.1.5</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,10 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>6.1.5</version>
+                <configuration>
+                    <!-- Skip temporarily due to https://github.com/jeremylong/DependencyCheck/issues/3310 -->
+                    <skip>true</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Update plugin `dependency-check-maven` to latest version. Plugin (both old and most recent versions) is broken due to parsing errors (see jeremylong/DependencyCheck#3310 for details), so disable the plugin temporarily until patched upstream.