### PR TITLE
EncodedPublicKey: properly implement PublicKey

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKey.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKey.java
@@ -47,7 +47,7 @@ import java.security.PublicKey;
  */
 public class EncodedPublicKey implements PublicKey {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private final ASN1Sequence sequence;
 

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKey.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKey.java
@@ -29,6 +29,11 @@
  */
 package net.ripe.rpki.commons.crypto.util;
 
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+
+import java.io.IOException;
 import java.security.PublicKey;
 
 /**
@@ -38,32 +43,42 @@ import java.security.PublicKey;
  * ResourceCertificateRequestData contains the encoded representation of
  * the subject public key and when it fed into the ResourceCertificateBuilder
  * (which send it further to X509CertificateBuilder) it is wrapped into
- * this class. As long as only the encoded representation of the key is used
- * this is sufficient.
+ * this class.
  */
 public class EncodedPublicKey implements PublicKey {
 
     private static final long serialVersionUID = 1L;
 
-    private final byte[] encoded;
+    private final ASN1Sequence sequence;
 
 
-    public EncodedPublicKey(byte[] encoded) { //NOPMD - ArrayIsStoredDirectly
-        this.encoded = encoded;
+    public EncodedPublicKey(byte[] encoded) {
+        this.sequence = ASN1Sequence.getInstance(encoded);
+        if (sequence.size() != 2) {
+            throw new IllegalArgumentException("Bad sequence size: " + sequence.size());
+        }
+        AlgorithmIdentifier algId = AlgorithmIdentifier.getInstance(sequence.getObjectAt(0));
+        if (!algId.getAlgorithm().on(PKCSObjectIdentifiers.pkcs_1)) {
+            throw new IllegalArgumentException("Not a PKCS#1 signature algorithm" + algId.getAlgorithm());
+        }
     }
 
     @Override
     public byte[] getEncoded() {
-        return encoded;
+        try {
+            return sequence.getEncoded();
+        } catch (IOException e) {
+            throw new IllegalStateException("Lost access to loaded public key data", e);
+        }
     }
 
     @Override
     public String getAlgorithm() {
-        throw new UnsupportedOperationException();
+        return "RSA";
     }
 
     @Override
     public String getFormat() {
-        throw new UnsupportedOperationException();
+        return "X.509";
     }
 }

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKeyTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKeyTest.java
@@ -32,33 +32,38 @@ package net.ripe.rpki.commons.crypto.util;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import java.security.PublicKey;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 
 public class EncodedPublicKeyTest {
 
-    private static final byte[] ENCODED_PUBLIC_KEY = new byte[]{0};
+    private static final PublicKey PUBLIC_KEY = KeyPairFactoryTest.TEST_KEY_PAIR.getPublic();
 
     public EncodedPublicKey subject;
 
 
     @Before
     public void setUp() {
-        subject = new EncodedPublicKey(ENCODED_PUBLIC_KEY);
+        // Make sure we're using an appropriate test key
+        assertEquals("RSA", PUBLIC_KEY.getAlgorithm());
+        subject = new EncodedPublicKey(PUBLIC_KEY.getEncoded());
     }
 
     @Test
     public void shouldReturnEncodedPart() {
-        assertEquals(ENCODED_PUBLIC_KEY, subject.getEncoded());
+        assertArrayEquals(PUBLIC_KEY.getEncoded(), subject.getEncoded());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldNotSpportFormat() {
-        subject.getFormat();
+    @Test
+    public void shouldReturnFormat() {
+        assertEquals(PUBLIC_KEY.getFormat(), subject.getFormat()); subject.getFormat();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldNotSpportAlgorithm() {
-        subject.getAlgorithm();
+    @Test
+    public void shouldReturnAlgorithm() {
+        assertEquals(PUBLIC_KEY.getAlgorithm(), subject.getAlgorithm());
     }
 }


### PR DESCRIPTION
Allow for `EncodedPublicKey` instances to be used as proper `PublicKey`
substitutes (fixing earlier substitution principle violations).