### PR TITLE
Document matchesFiles for future reviewers

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
@@ -126,7 +126,10 @@ public class ManifestCms extends RpkiSignedObject {
     }
 
     public boolean matchesFiles(Map<String, byte[]> filesToMatch) {
-
+        // A Manifest matches a set of files when:
+        //   * The file names are unique (implied by hashes being a Map),
+        //   * The manifest and the set of files contain the same file names, and
+        //   * For each file, the hash of the content matches the hash on the manifest.
         if (hashes.keySet().equals(filesToMatch.keySet())) {
             for (Entry<String, byte[]> entry : hashes.entrySet()) {
                 String fileName = entry.getKey();


### PR DESCRIPTION
Document why matchesFiles does what it does so a future reviewer can be sure that it matches this description when reading it once (instead of reconstructing why this algorithm is enough).

Note that while this approach is fine for generating objects (where we want uniqueness) this this may be unable to properly represent some manifests that contain multiple files with the same name.