### PR TITLE
Bump version to 1.22-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.ripe.rpki</groupId>
     <artifactId>rpki-commons</artifactId>
-    <version>1.21-SNAPSHOT</version>
+    <version>1.22-SNAPSHOT</version>
     <inceptionYear>2008</inceptionYear>
 
     <name>RPKI Commmons</name>


### PR DESCRIPTION
1.21 was released last week, but the release process doesn't automatically bump
the version.