### PR TITLE
document origin of check for inherited resources

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParser.java
@@ -94,6 +94,10 @@ public class ManifestCmsParser extends RpkiSignedObjectParser {
     private void validateManifest() {
         ValidationResult validationResult = getValidationResult();
         validationResult.rejectIfFalse(new ASN1ObjectIdentifier(ManifestCms.CONTENT_TYPE_OID).equals(getContentType()), MANIFEST_CONTENT_TYPE);
+        // RFC 6486 section 5.1.2:
+        // This EE certificate MUST describe its Internet Number Resources
+        // (INRs) using the "inherit" attribute, rather than explicit
+        // description of a resource set (see [RFC3779]).
         validationResult.rejectIfFalse(getResourceCertificate().isResourceSetInherited(), MANIFEST_RESOURCE_INHERIT);
     }
 


### PR DESCRIPTION
Check for inherited resource set is a MUST from RFC 6486 - document this.

This was kind of hard to debug when an object in a repository was rejected by the validator. That is hard to fix (because object errors for objects dropped during parsing are not listed and afterwards the manifest for an certificate is not found by it's hash). But at least we can clarify where the requirements come from.

@reviewers: Please also check where we implement
> This EE certificate MUST have an SIA extension access
> description field with an accessMethod OID value of
> `id-ad-signedobject`, where the associated accessLocation
> references the publication point of the manifest as an object
> URL.
