### PR TITLE
Include validation check in exception message

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -29,6 +29,7 @@
  */
 package net.ripe.rpki.commons.crypto.x509cert;
 
+import com.google.common.base.Joiner;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERIA5String;
@@ -48,6 +49,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import static net.ripe.rpki.commons.crypto.x509cert.AbstractX509CertificateWrapper.POLICY_OID;
 import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor.ID_AD_CA_REPOSITORY;
@@ -65,7 +67,12 @@ public class X509ResourceCertificateParser extends X509CertificateParser<X509Res
     @Override
     public X509ResourceCertificate getCertificate() {
         if (!isSuccess()) {
-            throw new IllegalArgumentException("Resource Certificate validation failed");
+            final String failures = Joiner.on(", ").join(
+                    result.getFailuresForAllLocations().stream()
+                          .map(validationCheck -> validationCheck.toString())
+                          .collect(Collectors.toList())
+            );
+            throw new IllegalArgumentException(String.format("Resource Certificate validation failed: %s", failures));
         }
         return new X509ResourceCertificate(getX509Certificate());
     }


### PR DESCRIPTION
Include the validation check in the exception message when a resource
certificate is rejected.

Improves
<img width="1159" alt="Screenshot 2021-06-02 at 17 27 58" src="https://user-images.githubusercontent.com/199058/120508288-e1d9fd00-c3c7-11eb-8ee2-c2f64a199b26.png">

To
<img width="1287" alt="Screenshot 2021-06-02 at 17 26 25" src="https://user-images.githubusercontent.com/199058/120508171-ca027900-c3c7-11eb-95db-ace716541070.png">
