### PR TITLE
Fix license notice

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The BSD License
 
-Copyright (c) 2010-2020 RIPE NCC
+Copyright (c) 2010-2021 RIPE NCC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ License
 Copyright (c) 2010-2021 RIPE NCC
 All rights reserved.
 
-This software is licensed under the terms of the BSD 3-Clause License. If a copy
-of the license was not distributed to you, you can obtain one at
+This software, including all its separate source codes, is licensed under the
+terms of the BSD 3-Clause License. If a copy of the license was not distributed
+to you, you can obtain one at
 https://github.com/RIPE-NCC/rpki-commons/blob/main/LICENSE.txt.
 
 Description

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ RPKI - Commons
 License
 -------
 
-This library is distributed under the BSD License.
-See: https://raw.github.com/RIPE-NCC/rpki-commons/master/LICENSE.txt
+Copyright (c) 2010-2021 RIPE NCC
+All rights reserved.
+
+This software is licensed under the terms of the BSD 3-Clause License. If a copy
+of the license was not distributed to you, you can obtain one at
+https://github.com/RIPE-NCC/rpki-commons/blob/main/LICENSE.txt.
 
 Description
 -----------

--- a/src/main/java/net/ripe/rpki/commons/crypto/CertificateRepositoryObject.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/CertificateRepositoryObject.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/CertificateRepositoryObjectFile.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/CertificateRepositoryObjectFile.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/JavaSecurityConstants.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/JavaSecurityConstants.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/UnknownCertificateRepositoryObject.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/UnknownCertificateRepositoryObject.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/ValidityPeriod.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/ValidityPeriod.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/CMSUtils.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/CMSUtils.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RPKIContentInfo.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RPKIContentInfo.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RPKISignedData.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RPKISignedData.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RPKISignedDataGenerator.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RPKISignedDataGenerator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObject.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObject.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectBuilderException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectBuilderException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectInfo.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectInfo.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/ghostbuster/GhostbustersCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/ghostbuster/GhostbustersCms.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/ghostbuster/GhostbustersCmsBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/ghostbuster/GhostbustersCmsBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/ghostbuster/GhostbustersCmsParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/ghostbuster/GhostbustersCmsParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsGeneralInfo.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsGeneralInfo.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/Roa.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/Roa.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCms.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefix.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefix.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/CrlLocator.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/CrlLocator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509Crl.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509Crl.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilderException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilderException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/AddressFamily.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/AddressFamily.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionEncoder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionEncoder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc8209/RouterExtensionEncoder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc8209/RouterExtensionEncoder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/Asn1Util.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/Asn1Util.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/Asn1UtilException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/Asn1UtilException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/BouncyCastleUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/BouncyCastleUtil.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactory.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactory.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectPrinter.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectPrinter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKey.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKey.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/KeyPairFactory.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/KeyPairFactory.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/KeyPairFactoryException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/KeyPairFactoryException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/KeyPairUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/KeyPairUtil.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/KeyStoreException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/KeyStoreException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/util/KeyStoreUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/util/KeyStoreUtil.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/AbstractX509CertificateWrapper.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/AbstractX509CertificateWrapper.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/AbstractX509CertificateWrapperException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/AbstractX509CertificateWrapperException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/CertificateInformationAccessUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/CertificateInformationAccessUtil.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/GenericRpkiCertificateBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/GenericRpkiCertificateBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/RpkiCaCertificateBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/RpkiCaCertificateBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/RpkiSignedObjectEeCertificateBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/RpkiSignedObjectEeCertificateBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelper.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateInformationAccessDescriptor.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateInformationAccessDescriptor.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateObject.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateObject.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateOperationException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateOperationException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtil.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509GenericCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509GenericCertificate.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificate.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateBuilderException.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateBuilderException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificate.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObject.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObject.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderException.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParser.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParserException.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParserException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/identity/ChildIdentity.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/identity/ChildIdentity.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/identity/ChildIdentitySerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/identity/ChildIdentitySerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/identity/IdentitySerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/identity/IdentitySerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/identity/ParentIdentity.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/identity/ParentIdentity.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/identity/ParentIdentitySerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/identity/ParentIdentitySerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/AbstractProvisioningPayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/AbstractProvisioningPayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/AbstractProvisioningPayloadXmlSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/AbstractProvisioningPayloadXmlSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/AbstractProvisioningQueryPayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/AbstractProvisioningQueryPayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/AbstractProvisioningResponsePayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/AbstractProvisioningResponsePayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/PayloadMessageType.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/PayloadMessageType.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/PayloadParser.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/PayloadParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/AbstractPayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/AbstractPayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/CertificateElement.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/CertificateElement.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/CertificateElementBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/CertificateElementBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/GenericClassElement.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/GenericClassElement.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/GenericClassElementBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/GenericClassElementBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/ResourceClassUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/ResourceClassUtil.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/X509ResourceCertificateBase64Converter.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/common/X509ResourceCertificateBase64Converter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/error/NotPerformedError.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/error/NotPerformedError.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/error/RequestNotPerformedResponsePayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/error/RequestNotPerformedResponsePayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/error/RequestNotPerformedResponsePayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/error/RequestNotPerformedResponsePayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/error/RequestNotPerformedResponsePayloadSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/error/RequestNotPerformedResponsePayloadSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestElement.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestElement.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestPayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestPayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestPayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestPayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestPayloadSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestPayloadSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponseClassElement.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponseClassElement.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponsePayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponsePayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponsePayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponsePayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponsePayloadSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponsePayloadSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/request/ResourceClassListQueryPayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/request/ResourceClassListQueryPayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/request/ResourceClassListQueryPayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/request/ResourceClassListQueryPayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/request/ResourceClassListQueryPayloadSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/request/ResourceClassListQueryPayloadSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponseClassElement.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponseClassElement.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponsePayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponsePayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponsePayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponsePayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponsePayloadSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponsePayloadSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/AbstractCertificateRevocationPayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/AbstractCertificateRevocationPayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/CertificateRevocationKeyElement.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/CertificateRevocationKeyElement.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestElement.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestElement.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestPayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestPayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestPayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestPayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestPayloadSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestPayloadSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/response/CertificateRevocationResponsePayload.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/response/CertificateRevocationResponsePayload.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/response/CertificateRevocationResponsePayloadBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/response/CertificateRevocationResponsePayloadBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/response/CertificateRevocationResponsePayloadSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/payload/revocation/response/CertificateRevocationResponsePayloadSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/protocol/ResponseExceptionType.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/protocol/ResponseExceptionType.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/serialization/CertificateUrlListConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/serialization/CertificateUrlListConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/serialization/IpResourceSetProvisioningConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/serialization/IpResourceSetProvisioningConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/serialization/ProvisioningCmsObjectXstreamConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/serialization/ProvisioningCmsObjectXstreamConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCertificate.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCertificateValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCertificateValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificate.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificate.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateBuilderException.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateBuilderException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateParser.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestBuilderException.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestBuilderException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestParser.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestParser.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestParserException.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestParserException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/rsync/Command.java
+++ b/src/main/java/net/ripe/rpki/commons/rsync/Command.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/rsync/CommandExecutionException.java
+++ b/src/main/java/net/ripe/rpki/commons/rsync/CommandExecutionException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/rsync/ProcessReader.java
+++ b/src/main/java/net/ripe/rpki/commons/rsync/ProcessReader.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/rsync/ProcessReaderException.java
+++ b/src/main/java/net/ripe/rpki/commons/rsync/ProcessReaderException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/rsync/RemoteCertificateFetcher.java
+++ b/src/main/java/net/ripe/rpki/commons/rsync/RemoteCertificateFetcher.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/rsync/RemoteCertificateFetcherException.java
+++ b/src/main/java/net/ripe/rpki/commons/rsync/RemoteCertificateFetcherException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/rsync/Rsync.java
+++ b/src/main/java/net/ripe/rpki/commons/rsync/Rsync.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/request/ResourceCertificateRequestData.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/request/ResourceCertificateRequestData.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/request/RevocationRequest.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/request/RevocationRequest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/request/SigningRequest.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/request/SigningRequest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/request/TaRequest.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/request/TaRequest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/request/TrustAnchorRequest.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/request/TrustAnchorRequest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/response/ErrorResponse.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/response/ErrorResponse.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/response/RevocationResponse.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/response/RevocationResponse.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/response/SigningResponse.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/response/SigningResponse.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/response/TaResponse.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/response/TaResponse.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/domain/response/TrustAnchorResponse.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/domain/response/TrustAnchorResponse.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorRequestSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorRequestSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorResponseSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorResponseSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/ConfigurationUtil.java
+++ b/src/main/java/net/ripe/rpki/commons/util/ConfigurationUtil.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/CsvFormatter.java
+++ b/src/main/java/net/ripe/rpki/commons/util/CsvFormatter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/EqualsSupport.java
+++ b/src/main/java/net/ripe/rpki/commons/util/EqualsSupport.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/RepositoryObjectType.java
+++ b/src/main/java/net/ripe/rpki/commons/util/RepositoryObjectType.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/Specification.java
+++ b/src/main/java/net/ripe/rpki/commons/util/Specification.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/Specifications.java
+++ b/src/main/java/net/ripe/rpki/commons/util/Specifications.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/UTC.java
+++ b/src/main/java/net/ripe/rpki/commons/util/UTC.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/VersionedId.java
+++ b/src/main/java/net/ripe/rpki/commons/util/VersionedId.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/util/XML.java
+++ b/src/main/java/net/ripe/rpki/commons/util/XML.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationCheck.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationCheck.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationChecks.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationChecks.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationLocation.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationLocation.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationMessage.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationMessage.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationMetric.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationMetric.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationOptions.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationResult.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationResult.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationStatus.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationStatus.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/ValidationString.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/CertificateRepositoryObjectValidationContext.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/CertificateRepositoryObjectValidationContext.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/CertificateRepositoryObjectValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/CertificateRepositoryObjectValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/RepositoryObjectValidationContext.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/RepositoryObjectValidationContext.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/ResourceCertificateLocator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/ResourceCertificateLocator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/ResourceValidatorFactory.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/ResourceValidatorFactory.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509CertificateParentChildValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509CertificateParentChildValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateBottomUpValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateBottomUpValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateParentChildLooseValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateParentChildLooseValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateParentChildValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateParentChildValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509ResourceCertificateValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509RouterCertificateValidator.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/objectvalidators/X509RouterCertificateValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/roa/AllowedRoute.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/roa/AllowedRoute.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/roa/AnnouncedRoute.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/roa/AnnouncedRoute.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/roa/RouteOriginValidationPolicy.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/roa/RouteOriginValidationPolicy.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/validation/roa/RouteValidityState.java
+++ b/src/main/java/net/ripe/rpki/commons/validation/roa/RouteValidityState.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/AliasedNetRipeTypePermission.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/AliasedNetRipeTypePermission.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/DomXmlSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/DomXmlSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/DomXmlSerializerException.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/DomXmlSerializerException.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/XStreamXmlSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/XStreamXmlSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/XStreamXmlSerializerBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/XStreamXmlSerializerBuilder.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/XmlSerializer.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/XmlSerializer.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/DateTimeConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/DateTimeConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/IpResourceConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/IpResourceConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/IpResourceSetConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/IpResourceSetConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/JavaUtilTimestampConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/JavaUtilTimestampConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/ManifestCmsConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/ManifestCmsConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/ReadablePeriodConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/ReadablePeriodConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/RoaCmsConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/RoaCmsConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/URIConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/URIConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/VersionedIdConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/VersionedIdConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/X500PrincipalConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/X500PrincipalConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/net/ripe/rpki/commons/xml/converters/X509ResourceCertificateConverter.java
+++ b/src/main/java/net/ripe/rpki/commons/xml/converters/X509ResourceCertificateConverter.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/resources/validation_en.properties
+++ b/src/main/resources/validation_en.properties
@@ -1,7 +1,7 @@
 #
 # The BSD License
 #
-# Copyright (c) 2010-2020 RIPE NCC
+# Copyright (c) 2010-2021 RIPE NCC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/FixedDateRule.java
+++ b/src/test/java/net/ripe/rpki/commons/FixedDateRule.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/ValidityPeriodTest.java
+++ b/src/test/java/net/ripe/rpki/commons/ValidityPeriodTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/RPKISignedDataGeneratorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/RPKISignedDataGeneratorTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/ghostbuster/GhostbustersCmsParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/ghostbuster/GhostbustersCmsParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCMSBuilderPropertyTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCMSBuilderPropertyTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/RpkiSignedObjectEeCertificateBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/RpkiSignedObjectEeCertificateBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCMSBuilderPropertyTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCMSBuilderPropertyTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsObjectMother.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsObjectMother.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlValidatorTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/AddressFamilyTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/AddressFamilyTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionEncoderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionEncoderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/Asn1UtilTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/Asn1UtilTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectFactoryTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectPrinterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/CertificateRepositoryObjectPrinterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKeyTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/EncodedPublicKeyTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/KeyPairFactoryTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/KeyPairFactoryTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/KeyPairUtilTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/KeyPairUtilTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/KeyStoreUtilTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/KeyStoreUtilTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/PregeneratedKeyPairFactory.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/PregeneratedKeyPairFactory.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelperTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderHelperTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderTestUtils.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateBuilderTestUtils.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtilTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509CertificateUtilTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificateTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/x509cert/X509RouterCertificateTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/interop/BBNCertificateConformanceTest.java
+++ b/src/test/java/net/ripe/rpki/commons/interop/BBNCertificateConformanceTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/interop/BBNCrlConformanceTest.java
+++ b/src/test/java/net/ripe/rpki/commons/interop/BBNCrlConformanceTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/interop/BBNRoaConformanceTest.java
+++ b/src/test/java/net/ripe/rpki/commons/interop/BBNRoaConformanceTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/interop/FailingAfrinicRoaTest.java
+++ b/src/test/java/net/ripe/rpki/commons/interop/FailingAfrinicRoaTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/ProvisioningObjectMother.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/ProvisioningObjectMother.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/cms/ProvisioningCmsObjectValidatorTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/identity/ChildIdentitySerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/identity/ChildIdentitySerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/identity/ParentIdentitySerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/identity/ParentIdentitySerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/CreateObjectsForInteropTesting.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/CreateObjectsForInteropTesting.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessApnicPdusTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessApnicPdusTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/interop/ProcessIscUpdownPdusTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/PayloadParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/PayloadParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/RelaxNgSchemaValidator.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/RelaxNgSchemaValidator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/common/GenericClassElementBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/common/GenericClassElementBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/error/RequestNotPerformedResponsePayloadSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/error/RequestNotPerformedResponsePayloadSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestPayloadSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/issue/request/CertificateIssuanceRequestPayloadSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponsePayloadSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/issue/response/CertificateIssuanceResponsePayloadSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/list/request/ResourceClassListQueryPayloadSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/list/request/ResourceClassListQueryPayloadSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponsePayloadSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/list/response/ResourceClassListResponsePayloadSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestPayloadSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/revocation/request/CertificateRevocationRequestPayloadSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/payload/revocation/response/CertificateRevocationResponsePayloadBuilderSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/payload/revocation/response/CertificateRevocationResponsePayloadBuilderSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/serialization/CertificateUrlListConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/serialization/CertificateUrlListConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/serialization/IpResourceSetProvisioningConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/serialization/IpResourceSetProvisioningConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/serialization/ProvisioningCmsObjectXstreamConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/serialization/ProvisioningCmsObjectXstreamConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningIdentityCertificateTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestBuilderParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/x509/pkcs10/RpkiCaCertificateRequestBuilderParserTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/rsync/CommandTest.java
+++ b/src/test/java/net/ripe/rpki/commons/rsync/CommandTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/rsync/ProcessReaderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/rsync/ProcessReaderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/rsync/RemoteCertificateFetcherTest.java
+++ b/src/test/java/net/ripe/rpki/commons/rsync/RemoteCertificateFetcherTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/rsync/RsyncTest.java
+++ b/src/test/java/net/ripe/rpki/commons/rsync/RsyncTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorRequestSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorRequestSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorResponseSerializerTest.java
+++ b/src/test/java/net/ripe/rpki/commons/ta/serializers/TrustAnchorResponseSerializerTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/ta/serializers/Utils.java
+++ b/src/test/java/net/ripe/rpki/commons/ta/serializers/Utils.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/util/CsvFormatterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/util/CsvFormatterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/util/VersionedIdTest.java
+++ b/src/test/java/net/ripe/rpki/commons/util/VersionedIdTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/util/XMLTest.java
+++ b/src/test/java/net/ripe/rpki/commons/util/XMLTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/CertificateRepositoryObjectValidationContextTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/CertificateRepositoryObjectValidationContextTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/ValidationMessageTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/ValidationMessageTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/ValidationResultTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/ValidationResultTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/ValidationStatusTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/ValidationStatusTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/ValidationStringTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/ValidationStringTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateBottomUpValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateBottomUpValidatorTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateParentChildValidatorTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/X509ResourceCertificateParentChildValidatorTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/interop/BBNConformanceTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/interop/BBNConformanceTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/interop/RpkidObjectsInteropTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/interop/RpkidObjectsInteropTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/properties/IpResourceGen.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/properties/IpResourceGen.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/properties/ResourceGenerator.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/properties/ResourceGenerator.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/validation/roa/RouteOriginValidationPolicyTest.java
+++ b/src/test/java/net/ripe/rpki/commons/validation/roa/RouteOriginValidationPolicyTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/xml/AliasedNetRipeTypePermissionTest.java
+++ b/src/test/java/net/ripe/rpki/commons/xml/AliasedNetRipeTypePermissionTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/xml/XStreamXmlSerializerBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/xml/XStreamXmlSerializerBuilderTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/xml/converters/DateTimeConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/xml/converters/DateTimeConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/xml/converters/ManifestCmsConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/xml/converters/ManifestCmsConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/xml/converters/ReadablePeriodConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/xml/converters/ReadablePeriodConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/xml/converters/RoaCmsConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/xml/converters/RoaCmsConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/xml/converters/VersionedIdConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/xml/converters/VersionedIdConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/net/ripe/rpki/commons/xml/converters/X509ResourceCertificateConverterTest.java
+++ b/src/test/java/net/ripe/rpki/commons/xml/converters/X509ResourceCertificateConverterTest.java
@@ -1,7 +1,7 @@
 /**
  * The BSD License
  *
- * Copyright (c) 2010-2020 RIPE NCC
+ * Copyright (c) 2010-2021 RIPE NCC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Bump copyright year to 2021 (just in time :)). Also, have a bit better license notice in README (updated with our legal department).