### PR TITLE
Bouncy castle 1.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ POM version to `1.0` and then builds and releases the artifacts.
   * Check KeyUsage bits in resource certificates
   * Added multiple BBN compliance test certificates as unit-tests
   * Simplified Base64 encoding
+  * Use and support bouncy castle 1.70
 
 ### 2021-08-31 version 1.24,1.25
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <java.runtime.version>1.8</java.runtime.version>
 
         <net.ripe.ipresource.version>1.47</net.ripe.ipresource.version>
-        <bouncycastle.version>1.69</bouncycastle.version>
+        <bouncycastle.version>1.70</bouncycastle.version>
         <guava.version>30.1.1-jre</guava.version>
         <joda-time.version>2.10.10</joda-time.version>
         <xstream.version>1.4.18</xstream.version>

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RPKIContentInfo.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RPKIContentInfo.java
@@ -61,28 +61,6 @@ public class RPKIContentInfo
         return getInstance(ASN1Sequence.getInstance(obj, explicit));
     }
 
-    /**
-     * @deprecated use getInstance()
-     */
-    @Deprecated
-    public RPKIContentInfo(ASN1Sequence seq) {
-        super(seq);
-        if (seq.size() < 1 || seq.size() > 2) {
-            throw new IllegalArgumentException("Bad sequence size: " + seq.size());
-        }
-
-        contentType = (ASN1ObjectIdentifier) seq.getObjectAt(0);
-
-        if (seq.size() > 1) {
-            ASN1TaggedObject tagged = (ASN1TaggedObject) seq.getObjectAt(1);
-            if (!tagged.isExplicit() || tagged.getTagNo() != 0) {
-                throw new IllegalArgumentException("Bad tag for 'content'");
-            }
-
-            content = tagged.getObject();
-        }
-    }
-
     public RPKIContentInfo(
         ASN1ObjectIdentifier contentType,
         ASN1Encodable        content)

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/RpkiSignedObjectParser.java
@@ -36,11 +36,6 @@ import static net.ripe.rpki.commons.crypto.cms.RpkiSignedObject.DIGEST_ALGORITHM
 import static net.ripe.rpki.commons.validation.ValidationString.*;
 
 public abstract class RpkiSignedObjectParser {
-
-    // binary-signing-time is not yet in BC CMSAttributes; define it here until
-    // https://github.com/bcgit/bc-java/pull/932 is merged.
-    public static final ASN1ObjectIdentifier BINARY_SIGNING_TIME_OID = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.2.46");
-
     private static final int CMS_OBJECT_VERSION = 3;
     private static final int CMS_OBJECT_SIGNER_VERSION = 3;
 
@@ -250,10 +245,10 @@ public abstract class RpkiSignedObjectParser {
         ASN1ObjectIdentifier attributeOID = signedAttribute.getAttrType();
 
         //Check if the attribute is any of the allowed ones.
-        return BINARY_SIGNING_TIME_OID.equals(attributeOID)
+        return CMSAttributes.binarySigningTime.equals(attributeOID)
                 || CMSAttributes.signingTime.equals(attributeOID)
                 || CMSAttributes.contentType.equals(attributeOID)
-                        || CMSAttributes.messageDigest.equals(attributeOID);
+                || CMSAttributes.messageDigest.equals(attributeOID);
     }
 
     private boolean verifyOptionalSignedAttributes(SignerInformation signer) {
@@ -325,7 +320,7 @@ public abstract class RpkiSignedObjectParser {
      */
     private boolean extractSigningTime(SignerInformation signer) {
         ImmutablePair<DateTime, Boolean> signingTime = extractTime(CMSAttributes.signingTime, ONLY_ONE_SIGNING_TIME_ATTR, signer);
-        ImmutablePair<DateTime, Boolean> binarySigningTime = extractTime(BINARY_SIGNING_TIME_OID, ONLY_ONE_BINARY_SIGNING_TIME_ATTR, signer);
+        ImmutablePair<DateTime, Boolean> binarySigningTime = extractTime(CMSAttributes.binarySigningTime, ONLY_ONE_BINARY_SIGNING_TIME_ATTR, signer);
         boolean valid = signingTime.right && binarySigningTime.right;
 
         if (signingTime.left != null && binarySigningTime.left != null) {

--- a/src/test/java/net/ripe/rpki/commons/crypto/util/Asn1UtilTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/util/Asn1UtilTest.java
@@ -22,8 +22,9 @@ public class Asn1UtilTest {
         parseIpAddressAsPrefix(IpResourceType.IPv4, decode(WRONG_ENCODED_IPV4_10_5_0_0_23));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void shouldFailIPv4ParsingWhenNoValidDerBitStringFoundP() {
+        // bouncy castle 1.70 catches this invalid case when decoding
         byte[] WRONG_ENCODED_IPV4_10_5_0_0_23 = {0x05, 0x04, 0x01, 0x0a, 0x05, 0x01};
         parseIpAddressAsPrefix(IpResourceType.IPv4, decode(WRONG_ENCODED_IPV4_10_5_0_0_23));
     }


### PR DESCRIPTION
After #101 (because I expected merge conflicts in the README).

Changes for bouncy castle 1.70  
  * Remove deprecated (and unused in RIPE NCC rpki projects) constructor
    in our DER ContentInfo copy
  * Patch test that decodes illegal input that bouncy castle now rejects
  * Finally use binarysigningtime attribute from bouncycatle that we added with a PR on bouncy castle.
