### PR TITLE
Update RFC 6492 validity period handling

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateBuilder.java
@@ -43,12 +43,17 @@ import java.security.PublicKey;
 
 public class ProvisioningCmsCertificateBuilder {
 
-    private static final int DEFAULT_VALIDITY_TIME_DAYS_FROM_NOW = 1;
+    private static final int DEFAULT_VALIDITY_TIME_MINUTES_FROM_NOW = 15;
+    /** default validity before now - to compensate for clock drift */
+    private static final int DEFAULT_VALIDITY_TIME_MINUTES_BEFORE_NOW = 1;
 
     private X509CertificateBuilderHelper builderHelper;
 
     public ProvisioningCmsCertificateBuilder() {
         builderHelper = new X509CertificateBuilderHelper();
+
+        final DateTime now = UTC.dateTime();
+        builderHelper.withValidityPeriod(new ValidityPeriod(now.minusMinutes(DEFAULT_VALIDITY_TIME_MINUTES_BEFORE_NOW), now.plusMinutes(DEFAULT_VALIDITY_TIME_MINUTES_FROM_NOW)));
     }
 
     public ProvisioningCmsCertificateBuilder withSignatureProvider(String signatureProvider) {
@@ -81,6 +86,14 @@ public class ProvisioningCmsCertificateBuilder {
         return this;
     }
 
+    /**
+     * Override the <emph>default</emph> validity period of this EE certificate.
+     */
+    public ProvisioningCmsCertificateBuilder withValidityPeriod(ValidityPeriod validityPeriod) {
+        builderHelper.withValidityPeriod(validityPeriod);
+        return this;
+    }
+
     public ProvisioningCmsCertificate build() {
         setUpImplicitRequirementsForBuilderHelper();
         return new ProvisioningCmsCertificate(builderHelper.generateCertificate());
@@ -90,7 +103,5 @@ public class ProvisioningCmsCertificateBuilder {
         builderHelper.withCa(false);
         builderHelper.withKeyUsage(KeyUsage.digitalSignature);
         builderHelper.withAuthorityKeyIdentifier(true);
-        final DateTime now = UTC.dateTime();
-        builderHelper.withValidityPeriod(new ValidityPeriod(now, now.plusDays(DEFAULT_VALIDITY_TIME_DAYS_FROM_NOW)));
     }
 }

--- a/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/provisioning/x509/ProvisioningCmsCertificateBuilderTest.java
@@ -29,14 +29,19 @@
  */
 package net.ripe.rpki.commons.provisioning.x509;
 
+import net.ripe.rpki.commons.crypto.ValidityPeriod;
 import net.ripe.rpki.commons.crypto.util.PregeneratedKeyPairFactory;
 import net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor;
+import net.ripe.rpki.commons.util.UTC;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
 import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.Arrays;
 
 import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper.*;
@@ -135,6 +140,24 @@ public class ProvisioningCmsCertificateBuilderTest {
     public void shouldHaveNoSiaPointer() {
         X509CertificateInformationAccessDescriptor[] subjectInformationAccess = TEST_CMS_CERT.getSubjectInformationAccess();
         assertNull(subjectInformationAccess);
+    }
+
+    @Test
+    public void shouldSetDefaultValidityPeriod() {
+        final X509Certificate certificate = getTestProvisioningCmsCertificate().getCertificate();
+        final Duration validityDuration = Duration.between(certificate.getNotBefore().toInstant(), certificate.getNotAfter().toInstant());
+        assertTrue(validityDuration.compareTo(Duration.ofDays(1)) == -1);
+    }
+
+    @Test
+    public void shouldSetValidityPeriod() {
+        final DateTime now = UTC.dateTime();
+        final ValidityPeriod yearInDays = new ValidityPeriod(now, now.plusDays(365));
+
+        final X509Certificate certificate = subject.withValidityPeriod(yearInDays).build().getCertificate();
+
+        final Duration validityDuration = Duration.between(certificate.getNotBefore().toInstant(), certificate.getNotAfter().toInstant());
+        assertTrue(validityDuration.compareTo(Duration.ofDays(365)) == 0);
     }
 
     @Test


### PR DESCRIPTION
@erikrozendaal unfortunately this will break your branch, but I would like this before 2.0

  * Change default validity period to `now-1m ... now+15m`
  * Allow validity period to be set externally (allows changes w/o a
    release of commons)