### PR TITLE
guava, joda-time, saxon-he updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ POM version to `1.0` and then builds and releases the artifacts.
 
 ## Changelog
 
+### 2022-xx-xx version 1.27
+  * Daxon-HE, joda-time, guava dependencies updated to newer versions.
+
 ### 2022-01-20 version 1.26
 
   * LICENSE is now in README and repository and not explicitly part of each file.

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
 
         <net.ripe.ipresource.version>1.48</net.ripe.ipresource.version>
         <bouncycastle.version>1.70</bouncycastle.version>
-        <guava.version>30.1.1-jre</guava.version>
-        <joda-time.version>2.10.10</joda-time.version>
+        <guava.version>31.0.1-jre</guava.version>
+        <joda-time.version>2.10.13</joda-time.version>
         <xstream.version>1.4.18</xstream.version>
         <commons-io.version>2.11.0</commons-io.version>
     </properties>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>10.5</version>
+            <version>10.6</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.ripe.rpki</groupId>
     <artifactId>rpki-commons</artifactId>
-    <version>1.26-SNAPSHOT</version>
+    <version>1.27-SNAPSHOT</version>
     <inceptionYear>2008</inceptionYear>
 
     <name>RPKI Commmons</name>


### PR DESCRIPTION
Updated dependencies after whitesource notice (for non-vulnerable updates).

  * [x] I have updated the changelog in README.md
