### PR TITLE
Add class to represent RFC3779 the resource extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ POM version to `1.0` and then builds and releases the artifacts.
 
 ## Changelog
 
+### 2023-04-20 1.33
+  * Add `ResourceExtension` class to represent the RFC3779 resource extension.
+
 ### 2022-11-16 1.32
   * Use ImmutableResourceSet to store resources of X509ResourceCertificate.
     This breaks serialisation compatibility.

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
@@ -59,6 +59,13 @@ public class ResourceExtension implements Serializable {
         return new ResourceExtension(this.inheritedResourceTypes, mapper.apply(this.resources));
     }
 
+    /**
+     * Determines the effective resources based on the parent resources and this resource extensions inherited and
+     * specified resources.
+     *
+     * @param parentResources parent certificate's resources
+     * @return the effective resource set
+     */
     public ImmutableResourceSet deriveResources(ImmutableResourceSet parentResources) {
         if (inheritedResourceTypes.isEmpty()) {
             return this.resources;

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
@@ -22,10 +22,10 @@ public class ResourceExtension implements Serializable {
         }
     }
 
-    @NonNull Set<IpResourceType> inheritedResourceTypes;
+    @NonNull EnumSet<IpResourceType> inheritedResourceTypes;
     @NonNull ImmutableResourceSet resources;
 
-    private ResourceExtension(@NonNull Set<IpResourceType> inheritedResourceTypes, @NonNull ImmutableResourceSet resources) {
+    private ResourceExtension(@NonNull EnumSet<IpResourceType> inheritedResourceTypes, @NonNull ImmutableResourceSet resources) {
         Validate.isTrue(!inheritedResourceTypes.isEmpty() || !resources.isEmpty(), "empty resource extension");
         for (IpResourceType inheritedResourceType : inheritedResourceTypes) {
             if (resources.containsType(inheritedResourceType)) {
@@ -37,33 +37,28 @@ public class ResourceExtension implements Serializable {
         this.resources = resources;
     }
 
-    public static ResourceExtension of(Collection<IpResourceType> inheritedResourceTypes, ImmutableResourceSet resources) {
-        // EnumSet.copyOf is unsafe since it requires a non-empty set when the parameter is not already an EnumSet!
-        EnumSet<IpResourceType> inherited = EnumSet.noneOf(IpResourceType.class);
-        inherited.addAll(inheritedResourceTypes);
-        return new ResourceExtension(Collections.unmodifiableSet(inherited), resources);
+    public EnumSet<IpResourceType> getInheritedResourceTypes() {
+        return EnumSet.copyOf(inheritedResourceTypes);
+    }
+
+    public static ResourceExtension of(EnumSet<IpResourceType> inheritedResourceTypes, ImmutableResourceSet resources) {
+        return new ResourceExtension(EnumSet.copyOf(inheritedResourceTypes), resources);
     }
 
     public static ResourceExtension ofResources(ImmutableResourceSet resources) {
-        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.noneOf(IpResourceType.class)), resources);
+        return new ResourceExtension(EnumSet.noneOf(IpResourceType.class), resources);
     }
 
-    public static ResourceExtension ofInherited(Collection<IpResourceType> inheritedResourceTypes) {
-        // EnumSet.copyOf is unsafe since it requires a non-empty set when the parameter is not already an EnumSet!
-        EnumSet<IpResourceType> inherited = EnumSet.noneOf(IpResourceType.class);
-        inherited.addAll(inheritedResourceTypes);
-        return new ResourceExtension(Collections.unmodifiableSet(inherited), ImmutableResourceSet.empty());
+    public static ResourceExtension ofInherited(EnumSet<IpResourceType> inheritedResourceTypes) {
+        return new ResourceExtension(EnumSet.copyOf(inheritedResourceTypes), ImmutableResourceSet.empty());
     }
 
     public static ResourceExtension allInherited() {
-        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.allOf(IpResourceType.class)), ImmutableResourceSet.empty());
+        return new ResourceExtension(EnumSet.allOf(IpResourceType.class), ImmutableResourceSet.empty());
     }
 
-    public ResourceExtension withInheritedResourceTypes(Collection<IpResourceType> inheritedResourceTypes) {
-        // EnumSet.copyOf is unsafe since it requires a non-empty set when the parameter is not already an EnumSet!
-        EnumSet<IpResourceType> inherited = EnumSet.noneOf(IpResourceType.class);
-        inherited.addAll(inheritedResourceTypes);
-        return new ResourceExtension(Collections.unmodifiableSet(inherited), this.resources);
+    public ResourceExtension withInheritedResourceTypes(EnumSet<IpResourceType> inheritedResourceTypes) {
+        return new ResourceExtension(EnumSet.copyOf(inheritedResourceTypes), this.resources);
     }
 
     public ResourceExtension withResources(ImmutableResourceSet resources) {

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
@@ -16,6 +16,15 @@ import java.util.function.UnaryOperator;
 
 @Value
 public class ResourceExtension implements Serializable {
+    private static final ImmutableResourceSet[] RESOURCES_BY_TYPE;
+
+    static {
+        RESOURCES_BY_TYPE = new ImmutableResourceSet[IpResourceType.values().length];
+        for (IpResourceType type : IpResourceType.values()) {
+            RESOURCES_BY_TYPE[type.ordinal()] = ImmutableResourceSet.of(type.getMinimum().upTo(type.getMaximum()));
+        }
+    }
+
     @NonNull Set<IpResourceType> inheritedResourceTypes;
     @NonNull ImmutableResourceSet resources;
 
@@ -75,7 +84,7 @@ public class ResourceExtension implements Serializable {
         }
         ImmutableResourceSet result = this.resources;
         for (IpResourceType type : inheritedResourceTypes) {
-            result = result.union(parentResources.intersection(ImmutableResourceSet.of(type.getMinimum().upTo(type.getMaximum()))));
+            result = result.union(parentResources.intersection(RESOURCES_BY_TYPE[type.ordinal()]));
         }
         return result;
     }

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
@@ -8,10 +8,7 @@ import net.ripe.ipresource.IpResourceType;
 import org.apache.commons.lang3.Validate;
 
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Set;
+import java.util.*;
 import java.util.function.UnaryOperator;
 
 @Value
@@ -64,8 +61,11 @@ public class ResourceExtension implements Serializable {
         return new ResourceExtension(this.inheritedResourceTypes, resources);
     }
 
-    public ResourceExtension mapResources(UnaryOperator<ImmutableResourceSet> mapper) {
-        return new ResourceExtension(this.inheritedResourceTypes, mapper.apply(this.resources));
+    public Optional<ResourceExtension> mapResources(UnaryOperator<ImmutableResourceSet> mapper) {
+        ImmutableResourceSet updatedResources = mapper.apply(this.resources);
+        return this.inheritedResourceTypes.isEmpty() && updatedResources.isEmpty()
+            ? Optional.empty()
+            : Optional.of(new ResourceExtension(this.inheritedResourceTypes, updatedResources));
     }
 
     /**

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
@@ -38,7 +38,10 @@ public class ResourceExtension implements Serializable {
     }
 
     public static ResourceExtension of(Collection<IpResourceType> inheritedResourceTypes, ImmutableResourceSet resources) {
-        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.copyOf(inheritedResourceTypes)), resources);
+        // EnumSet.copyOf is unsafe since it requires a non-empty set when the parameter is not already an EnumSet!
+        EnumSet<IpResourceType> inherited = EnumSet.noneOf(IpResourceType.class);
+        inherited.addAll(inheritedResourceTypes);
+        return new ResourceExtension(Collections.unmodifiableSet(inherited), resources);
     }
 
     public static ResourceExtension ofResources(ImmutableResourceSet resources) {
@@ -46,7 +49,10 @@ public class ResourceExtension implements Serializable {
     }
 
     public static ResourceExtension ofInherited(Collection<IpResourceType> inheritedResourceTypes) {
-        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.copyOf(inheritedResourceTypes)), ImmutableResourceSet.empty());
+        // EnumSet.copyOf is unsafe since it requires a non-empty set when the parameter is not already an EnumSet!
+        EnumSet<IpResourceType> inherited = EnumSet.noneOf(IpResourceType.class);
+        inherited.addAll(inheritedResourceTypes);
+        return new ResourceExtension(Collections.unmodifiableSet(inherited), ImmutableResourceSet.empty());
     }
 
     public static ResourceExtension allInherited() {
@@ -54,7 +60,10 @@ public class ResourceExtension implements Serializable {
     }
 
     public ResourceExtension withInheritedResourceTypes(Collection<IpResourceType> inheritedResourceTypes) {
-        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.copyOf(inheritedResourceTypes)), this.resources);
+        // EnumSet.copyOf is unsafe since it requires a non-empty set when the parameter is not already an EnumSet!
+        EnumSet<IpResourceType> inherited = EnumSet.noneOf(IpResourceType.class);
+        inherited.addAll(inheritedResourceTypes);
+        return new ResourceExtension(Collections.unmodifiableSet(inherited), this.resources);
     }
 
     public ResourceExtension withResources(ImmutableResourceSet resources) {

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
@@ -84,4 +84,8 @@ public class ResourceExtension implements Serializable {
     public boolean containsResources(IpResourceSet that) {
         return resources.contains(that);
     }
+
+    public boolean containsResources(ImmutableResourceSet that) {
+        return resources.contains(that);
+    }
 }

--- a/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtension.java
@@ -1,0 +1,87 @@
+package net.ripe.rpki.commons.crypto.rfc3779;
+
+import lombok.NonNull;
+import lombok.Value;
+import net.ripe.ipresource.ImmutableResourceSet;
+import net.ripe.ipresource.IpResourceSet;
+import net.ripe.ipresource.IpResourceType;
+import org.apache.commons.lang3.Validate;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+@Value
+public class ResourceExtension implements Serializable {
+    @NonNull Set<IpResourceType> inheritedResourceTypes;
+    @NonNull ImmutableResourceSet resources;
+
+    private ResourceExtension(@NonNull Set<IpResourceType> inheritedResourceTypes, @NonNull ImmutableResourceSet resources) {
+        Validate.isTrue(!inheritedResourceTypes.isEmpty() || !resources.isEmpty(), "empty resource extension");
+        for (IpResourceType inheritedResourceType : inheritedResourceTypes) {
+            if (resources.containsType(inheritedResourceType)) {
+                throw new IllegalArgumentException("resources overlap with inherited resource type " + inheritedResourceType);
+            }
+        }
+
+        this.inheritedResourceTypes = inheritedResourceTypes;
+        this.resources = resources;
+    }
+
+    public static ResourceExtension of(Collection<IpResourceType> inheritedResourceTypes, ImmutableResourceSet resources) {
+        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.copyOf(inheritedResourceTypes)), resources);
+    }
+
+    public static ResourceExtension ofResources(ImmutableResourceSet resources) {
+        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.noneOf(IpResourceType.class)), resources);
+    }
+
+    public static ResourceExtension ofInherited(Collection<IpResourceType> inheritedResourceTypes) {
+        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.copyOf(inheritedResourceTypes)), ImmutableResourceSet.empty());
+    }
+
+    public static ResourceExtension allInherited() {
+        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.allOf(IpResourceType.class)), ImmutableResourceSet.empty());
+    }
+
+    public ResourceExtension withInheritedResourceTypes(Collection<IpResourceType> inheritedResourceTypes) {
+        return new ResourceExtension(Collections.unmodifiableSet(EnumSet.copyOf(inheritedResourceTypes)), this.resources);
+    }
+
+    public ResourceExtension withResources(ImmutableResourceSet resources) {
+        return new ResourceExtension(this.inheritedResourceTypes, resources);
+    }
+
+    public ResourceExtension mapResources(UnaryOperator<ImmutableResourceSet> mapper) {
+        return new ResourceExtension(this.inheritedResourceTypes, mapper.apply(this.resources));
+    }
+
+    public ImmutableResourceSet deriveResources(ImmutableResourceSet parentResources) {
+        if (inheritedResourceTypes.isEmpty()) {
+            return this.resources;
+        }
+        if (inheritedResourceTypes.containsAll(EnumSet.allOf(IpResourceType.class))) {
+            return parentResources;
+        }
+        ImmutableResourceSet result = this.resources;
+        for (IpResourceType type : inheritedResourceTypes) {
+            result = result.union(parentResources.intersection(ImmutableResourceSet.of(type.getMinimum().upTo(type.getMaximum()))));
+        }
+        return result;
+    }
+
+    public boolean isResourceTypesInherited(Collection<IpResourceType> resourceTypes) {
+        return inheritedResourceTypes.containsAll(resourceTypes);
+    }
+
+    public boolean isResourceSetInherited() {
+        return !inheritedResourceTypes.isEmpty();
+    }
+
+    public boolean containsResources(IpResourceSet that) {
+        return resources.contains(that);
+    }
+}

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificate.java
@@ -49,10 +49,7 @@ public class X509ResourceCertificate extends X509GenericCertificate implements X
     }
 
     public EnumSet<IpResourceType> getInheritedResourceTypes() {
-        // EnumSet.copyOf is unsafe since it requires a non-empty set when the parameter is not already an EnumSet!
-        EnumSet<IpResourceType> inherited = EnumSet.noneOf(IpResourceType.class);
-        inherited.addAll(resourceExtension.getInheritedResourceTypes());
-        return inherited;
+        return resourceExtension.getInheritedResourceTypes();
     }
 
     public boolean isResourceTypesInherited(EnumSet<IpResourceType> resourceTypes) {

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificate.java
@@ -49,7 +49,10 @@ public class X509ResourceCertificate extends X509GenericCertificate implements X
     }
 
     public EnumSet<IpResourceType> getInheritedResourceTypes() {
-        return EnumSet.copyOf(resourceExtension.getInheritedResourceTypes());
+        // EnumSet.copyOf is unsafe since it requires a non-empty set when the parameter is not already an EnumSet!
+        EnumSet<IpResourceType> inherited = EnumSet.noneOf(IpResourceType.class);
+        inherited.addAll(resourceExtension.getInheritedResourceTypes());
+        return inherited;
     }
 
     public boolean isResourceTypesInherited(EnumSet<IpResourceType> resourceTypes) {

--- a/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificate.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/x509cert/X509ResourceCertificate.java
@@ -134,7 +134,15 @@ public class X509ResourceCertificate extends X509GenericCertificate implements X
         return new IpResourceSet(resourceExtension.deriveResources(ImmutableResourceSet.of(parentResources)));
     }
 
+    public ImmutableResourceSet deriveResources(ImmutableResourceSet parentResources) {
+        return resourceExtension.deriveResources(parentResources);
+    }
+
     public boolean containsResources(IpResourceSet that) {
+        return resourceExtension.containsResources(that);
+    }
+
+    public boolean containsResources(ImmutableResourceSet that) {
         return resourceExtension.containsResources(that);
     }
 }

--- a/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionTest.java
@@ -1,0 +1,41 @@
+package net.ripe.rpki.commons.crypto.rfc3779;
+
+
+import net.ripe.ipresource.ImmutableResourceSet;
+import net.ripe.ipresource.IpResourceType;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ResourceExtensionTest {
+
+    @Test
+    public void should_enforce_non_empty_resource_extension() {
+        assertThatThrownBy(() -> ResourceExtension.ofResources(ImmutableResourceSet.empty())).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ResourceExtension.ofInherited(Collections.emptySet())).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void mapResources() {
+        assertThat(
+            ResourceExtension.ofResources(ImmutableResourceSet.ALL_PRIVATE_USE_RESOURCES)
+                .mapResources(ignored -> ImmutableResourceSet.empty())
+        ).isEmpty();
+        assertThat(
+            ResourceExtension.allInherited().mapResources(ignored -> ImmutableResourceSet.empty())
+        ).hasValueSatisfying(re -> {
+            assertThat(re.getInheritedResourceTypes()).containsExactly(IpResourceType.values());
+            assertThat(re.getResources()).isEqualTo(ImmutableResourceSet.empty());
+        });
+        assertThat(
+            ResourceExtension.ofResources(ImmutableResourceSet.ALL_PRIVATE_USE_RESOURCES)
+                .mapResources(r -> r.intersection(ImmutableResourceSet.parse("192.0.0.0/8")))
+        ).hasValueSatisfying(re -> {
+            assertThat(re.getResources()).isEqualTo(ImmutableResourceSet.parse("192.168.0.0/16"));
+            assertThat(re.isResourceSetInherited()).isFalse();
+        });
+    }
+}

--- a/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/rfc3779/ResourceExtensionTest.java
@@ -5,7 +5,7 @@ import net.ripe.ipresource.ImmutableResourceSet;
 import net.ripe.ipresource.IpResourceType;
 import org.junit.Test;
 
-import java.util.Collections;
+import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -15,7 +15,7 @@ public class ResourceExtensionTest {
     @Test
     public void should_enforce_non_empty_resource_extension() {
         assertThatThrownBy(() -> ResourceExtension.ofResources(ImmutableResourceSet.empty())).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ResourceExtension.ofInherited(Collections.emptySet())).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ResourceExtension.ofInherited(EnumSet.noneOf(IpResourceType.class))).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
Extracted from the `X509ResourceCertificate` class to allow use of resource extensions without needing a resource certificate.

  * [X] I have updated the changelog in README.md
