### PR TITLE
Finish generic signed object parser

### DIFF
--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/GenericRpkiSignedObjectParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/GenericRpkiSignedObjectParser.java
@@ -2,6 +2,7 @@ package net.ripe.rpki.commons.crypto.cms;
 
 import net.ripe.rpki.commons.crypto.cms.aspa.AspaCms;
 import net.ripe.rpki.commons.crypto.cms.ghostbuster.GhostbustersCms;
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
 import net.ripe.rpki.commons.crypto.cms.roa.RoaCms;
 import net.ripe.rpki.commons.util.RepositoryObjectType;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -20,10 +21,12 @@ public class GenericRpkiSignedObjectParser extends RpkiSignedObjectParser {
         final ASN1ObjectIdentifier contentType = getContentType();
         if (AspaCms.CONTENT_TYPE.equals(contentType)) {
             return Optional.of(Aspa);
-        } else if (RoaCms.CONTENT_TYPE.equals(contentType)) {
-            return Optional.of(Roa);
         } else if (GhostbustersCms.CONTENT_TYPE.equals(contentType)) {
             return Optional.of(Gbr);
+        } else if (ManifestCms.CONTENT_TYPE.equals(contentType)) {
+            return Optional.of(Manifest);
+        } else if (RoaCms.CONTENT_TYPE.equals(contentType)) {
+            return Optional.of(Roa);
         }
         return Optional.empty();
     }

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCms.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.cms.CMSSignedDataGenerator;
 import org.bouncycastle.crypto.Digest;
 import org.bouncycastle.crypto.digests.SHA256Digest;
@@ -41,7 +42,11 @@ public class ManifestCms extends RpkiSignedObject {
 
     public static final int DEFAULT_VERSION = 0;
 
+    // since 1.34
+    @Deprecated
     public static final String CONTENT_TYPE_OID = "1.2.840.113549.1.9.16.1.26";
+
+    public static final ASN1ObjectIdentifier CONTENT_TYPE = new ASN1ObjectIdentifier("1.2.840.113549.1.9.16.1.26");
 
     public static final String FILE_HASH_ALGORITHM = CMSSignedDataGenerator.DIGEST_SHA256;
 

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilder.java
@@ -65,7 +65,7 @@ public class ManifestCmsBuilder extends RpkiSignedObjectBuilder {
     public ManifestCms build(PrivateKey privateKey) {
         String location = "unknown.mft";
         ManifestCmsParser parser = new ManifestCmsParser();
-        parser.parse(ValidationResult.withLocation(location), generateCms(certificate.getCertificate(), privateKey, signatureProvider, new ASN1ObjectIdentifier(ManifestCms.CONTENT_TYPE_OID), encodeManifest()));
+        parser.parse(ValidationResult.withLocation(location), generateCms(certificate.getCertificate(), privateKey, signatureProvider, ManifestCms.CONTENT_TYPE, encodeManifest()));
         return parser.getManifestCms();
     }
 

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParser.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParser.java
@@ -64,7 +64,7 @@ public class ManifestCmsParser extends RpkiSignedObjectParser {
 
     private void validateManifest() {
         ValidationResult validationResult = getValidationResult();
-        validationResult.rejectIfFalse(new ASN1ObjectIdentifier(ManifestCms.CONTENT_TYPE_OID).equals(getContentType()), MANIFEST_CONTENT_TYPE);
+        validationResult.rejectIfFalse(ManifestCms.CONTENT_TYPE.equals(getContentType()), MANIFEST_CONTENT_TYPE);
         // RFC 6486 section 5.1.2:
         // This EE certificate MUST describe its Internet Number Resources
         // (INRs) using the "inherit" attribute, rather than explicit

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/GenericRpkiSignedObjectParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/GenericRpkiSignedObjectParserTest.java
@@ -8,9 +8,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GenericRpkiSignedObjectParserTest {
     @Test
@@ -21,15 +20,6 @@ public class GenericRpkiSignedObjectParserTest {
         assertThat(parser.getSigningTime()).isEqualTo(DateTime.parse("2021-11-11T11:19:00+00:00"));
     }
 
-    @Test
-    void should_parse_roa() throws IOException {
-        GenericRpkiSignedObjectParser parser = parse("interop/rpkid-objects/nI2bsx18I5mlex8lBpY0WSJUYio.roa");
-
-        assertThat(parser.getRepositoryObjectType().get()).isEqualTo(RepositoryObjectType.Roa);
-        assertThat(parser.getSigningTime()).isEqualTo(DateTime.parse("2011-11-11T01:55:18+00:00"));
-    }
-
-
     @Disabled("Our parser rejects GBR objects: corrupted stream - out of bounds length found: 115 >= 32")
     @Test
     void should_parse_gbr() throws IOException {
@@ -38,6 +28,23 @@ public class GenericRpkiSignedObjectParserTest {
         assertThat(parser.getRepositoryObjectType().get()).isEqualTo(RepositoryObjectType.Gbr);
         assertThat(parser.getSigningTime()).isEqualTo(DateTime.parse("2016-08-19T12:10:32+00:00"));
     }
+
+    @Test
+    void should_parse_manifest() throws IOException {
+        GenericRpkiSignedObjectParser parser = parse("conformance/root/root.mft");
+
+        assertThat(parser.getRepositoryObjectType().get()).isEqualTo(RepositoryObjectType.Manifest);
+        assertThat(parser.getSigningTime()).isEqualTo(DateTime.parse("2013-10-28T21:24:39+00:00"));
+    }
+
+    @Test
+    void should_parse_roa() throws IOException {
+        GenericRpkiSignedObjectParser parser = parse("interop/rpkid-objects/nI2bsx18I5mlex8lBpY0WSJUYio.roa");
+
+        assertThat(parser.getRepositoryObjectType().get()).isEqualTo(RepositoryObjectType.Roa);
+        assertThat(parser.getSigningTime()).isEqualTo(DateTime.parse("2011-11-11T01:55:18+00:00"));
+    }
+
 
     private GenericRpkiSignedObjectParser parse(String path) throws IOException {
         byte[] bytes = Resources.toByteArray(Resources.getResource(path));


### PR DESCRIPTION
Finished the generic signed object parser. This time not pushing to main (`stash, checkout, pull, pop, [forget to switch branch and rebase], commit, push`). One additional benefit is that we can use this for conformance testing Signed Object specific checks w/o also relying on object parsing.

This could be moved in RpkiSignedObjectParser if that is made non-abstract.

  * [ ] I have updated the changelog in README.md
