### PR TITLE
Add withValidityPeriod to MFT and CRL builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ next (snapshot) release, e.g. `1.1-SNAPSHOT` after releasing `1.0`.
 
 ## 2024-xx-xx
   * Add support for router certificates to the time parsing in `SignedObjectUtil`.
+  * Add withValidityPeriod to manifest and CRL builders
 
 ## 2023-10-31 1.36
   * Access the certificate for the generic signed object parser.

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilder.java
@@ -1,5 +1,6 @@
 package net.ripe.rpki.commons.crypto.cms.manifest;
 
+import net.ripe.rpki.commons.crypto.ValidityPeriod;
 import net.ripe.rpki.commons.crypto.cms.RpkiSignedObjectBuilder;
 import net.ripe.rpki.commons.crypto.util.Asn1Util;
 import net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper;
@@ -54,6 +55,13 @@ public class ManifestCmsBuilder extends RpkiSignedObjectBuilder {
 
     public ManifestCmsBuilder withNextUpdateTime(DateTime instant) {
         this.nextUpdateTime = instant;
+        return this;
+    }
+
+    // This is preferred since ValidityPeriod will validate the dates
+    public ManifestCmsBuilder withValidityPeriod(ValidityPeriod validityPeriod) {
+        this.thisUpdateTime = validityPeriod.getNotValidBefore();
+        this.nextUpdateTime = validityPeriod.getNotValidAfter();
         return this;
     }
 

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilder.java
@@ -48,11 +48,19 @@ public class ManifestCmsBuilder extends RpkiSignedObjectBuilder {
         return this;
     }
 
+    /**
+     * @deprecated Use {@link #withValidityPeriod} instead
+     */
+    @Deprecated
     public ManifestCmsBuilder withThisUpdateTime(DateTime instant) {
         this.thisUpdateTime = instant;
         return this;
     }
 
+    /**
+     * @deprecated Use {@link #withValidityPeriod} instead
+     */
+    @Deprecated
     public ManifestCmsBuilder withNextUpdateTime(DateTime instant) {
         this.nextUpdateTime = instant;
         return this;

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilder.java
@@ -53,11 +53,20 @@ public class X509CrlBuilder {
         return this;
     }
 
+    /**
+     * @deprecated Use {@link #withValidityPeriod} instead
+     */
+    @Deprecated
     public X509CrlBuilder withThisUpdateTime(DateTime instant) {
         this.thisUpdateTime = instant;
         return this;
     }
 
+
+    /**
+     * @deprecated Use {@link #withValidityPeriod} instead
+     */
+    @Deprecated
     public X509CrlBuilder withNextUpdateTime(DateTime instant) {
         this.nextUpdateTime = instant;
         return this;

--- a/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilder.java
@@ -1,5 +1,8 @@
 package net.ripe.rpki.commons.crypto.crl;
 
+import lombok.Getter;
+import net.ripe.rpki.commons.crypto.ValidityPeriod;
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCmsBuilder;
 import net.ripe.rpki.commons.crypto.crl.X509Crl.Entry;
 import net.ripe.rpki.commons.crypto.util.BouncyCastleUtil;
 import net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper;
@@ -29,7 +32,9 @@ public class X509CrlBuilder {
     public static final int CRL_VERSION_2 = 2;
 
     private X500Principal issuerDN;
+    @Getter
     private DateTime thisUpdateTime;
+    @Getter
     private DateTime nextUpdateTime;
     private AuthorityKeyIdentifier authorityKeyIdentifier;
     private CRLNumber crlNumber;
@@ -53,18 +58,18 @@ public class X509CrlBuilder {
         return this;
     }
 
-    public DateTime getThisUpdateTime() {
-        return thisUpdateTime;
-    }
-
     public X509CrlBuilder withNextUpdateTime(DateTime instant) {
         this.nextUpdateTime = instant;
         return this;
     }
 
-    public DateTime getNextUpdateTime() {
-        return nextUpdateTime;
+    // This is preferred since ValidityPeriod will validate the dates
+    public X509CrlBuilder withValidityPeriod(ValidityPeriod validityPeriod) {
+        this.thisUpdateTime = validityPeriod.getNotValidBefore();
+        this.nextUpdateTime = validityPeriod.getNotValidAfter();
+        return this;
     }
+
 
     /**
      * CRL number must be representable in 20 octets

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCMSBuilderPropertyTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCMSBuilderPropertyTest.java
@@ -2,6 +2,7 @@ package net.ripe.rpki.commons.crypto.cms.manifest;
 
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import net.ripe.rpki.commons.crypto.ValidityPeriod;
 import org.joda.time.DateTime;
 import org.junit.runner.RunWith;
 
@@ -14,27 +15,21 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnitQuickcheck.class)
 public class ManifestCMSBuilderPropertyTest {
+    @Property
+    public void buildEncodedParseCheck(byte[] content, BigInteger manifestNumber, Integer validityHours) {
+        ManifestCmsBuilder builder = new ManifestCmsBuilder();
+        builder.addFile("test.crl", content);
+        builder.withManifestNumber(manifestNumber);
+        builder.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
+        builder.withCertificate(createValidManifestEECertificate(TEST_KEY_PAIR));
+        DateTime start = DateTime.now();
+        builder.withValidityPeriod(new ValidityPeriod(start, start.plusHours(Math.abs(validityHours))));
+        ManifestCms manifestCms = builder.build(TEST_KEY_PAIR.getPrivate());
 
-    @Property public void buildEncodedParseCheck(
-            byte[] content,
-            BigInteger manifestNumber,
-            Integer validityHours
-    ){
-            ManifestCmsBuilder builder = new ManifestCmsBuilder();
-            builder.addFile("test.crl", content);
-            builder.withManifestNumber(manifestNumber);
-            builder.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
-            builder.withCertificate(createValidManifestEECertificate(TEST_KEY_PAIR));
-            DateTime start = DateTime.now();
-            builder.withThisUpdateTime(start);
-            builder.withNextUpdateTime(start.plusHours(validityHours));
-            ManifestCms manifestCms = builder.build(TEST_KEY_PAIR.getPrivate());
-
-            ManifestCmsParser mftParser = new ManifestCmsParser();
-            mftParser.parse("test.mft", manifestCms.getEncoded());
-            assertTrue(mftParser.getManifestCms().containsFile("test.crl"));
+        ManifestCmsParser mftParser = new ManifestCmsParser();
+        mftParser.parse("test.mft", manifestCms.getEncoded());
+        assertTrue(mftParser.getManifestCms().containsFile("test.crl"));
     }
-
 
 }
 

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilderTest.java
@@ -1,6 +1,7 @@
 package net.ripe.rpki.commons.crypto.cms.manifest;
 
 import net.ripe.rpki.commons.FixedDateRule;
+import net.ripe.rpki.commons.crypto.ValidityPeriod;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Before;
 import org.junit.Rule;
@@ -95,5 +96,28 @@ public class ManifestCmsBuilderTest {
         subject.addFile("foo1", FOO_CONTENT);
         subject.addFile("BaR", BAR_CONTENT);
         assertArrayEquals(ENCODED_MANIFEST, subject.encodeManifest());
+    }
+
+    @Test
+    public void shouldBeEquivalentToSetDateInDifferentWays() {
+        var builder1 = new ManifestCmsBuilder();
+        builder1.withManifestNumber(BigInteger.valueOf(68));
+        builder1.withThisUpdateTime(THIS_UPDATE_TIME);
+        builder1.withNextUpdateTime(NEXT_UPDATE_TIME);
+        builder1.withCertificate(createValidManifestEECertificate());
+        builder1.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
+
+        var builder2 = new ManifestCmsBuilder();
+        builder2.withManifestNumber(BigInteger.valueOf(68));
+        builder2.withValidityPeriod(new ValidityPeriod(THIS_UPDATE_TIME, NEXT_UPDATE_TIME));
+        builder2.withNextUpdateTime(NEXT_UPDATE_TIME);
+        builder2.withCertificate(createValidManifestEECertificate());
+        builder2.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
+
+        ManifestCms m1 = builder1.build(TEST_KEY_PAIR.getPrivate());
+        ManifestCms m2 = builder1.build(TEST_KEY_PAIR.getPrivate());
+
+        assertEquals(m1.getThisUpdateTime(), m2.getThisUpdateTime());
+        assertEquals(m1.getNextUpdateTime(), m2.getNextUpdateTime());
     }
 }

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilderTest.java
@@ -98,6 +98,7 @@ public class ManifestCmsBuilderTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldBeEquivalentToSetDateInDifferentWays() {
         var builder1 = new ManifestCmsBuilder();
         builder1.withManifestNumber(BigInteger.valueOf(68));

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsBuilderTest.java
@@ -27,8 +27,7 @@ public class ManifestCmsBuilderTest {
     @Before
     public void setUp() {
         subject.withManifestNumber(BigInteger.valueOf(68));
-        subject.withThisUpdateTime(THIS_UPDATE_TIME);
-        subject.withNextUpdateTime(NEXT_UPDATE_TIME);
+        subject.withValidityPeriod(new ValidityPeriod(THIS_UPDATE_TIME, NEXT_UPDATE_TIME));
         subject.withCertificate(createValidManifestEECertificate());
         subject.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParserTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsParserTest.java
@@ -144,7 +144,7 @@ public class ManifestCmsParserTest {
         DateTimeUtils.setCurrentMillisFixed(THIS_UPDATE_TIME.getMillis());
         ManifestCmsBuilder builder = new ManifestCmsBuilder();
         builder.withCertificate(createValidManifestEECertificate()).withManifestNumber(BigInteger.valueOf(68));
-        builder.withThisUpdateTime(THIS_UPDATE_TIME).withNextUpdateTime(NEXT_UPDATE_TIME);
+        builder.withValidityPeriod(new ValidityPeriod(THIS_UPDATE_TIME, NEXT_UPDATE_TIME));
         builder.addFile("foo1", FOO_CONTENT);
         builder.addFile("BaR", BAR_CONTENT);
         builder.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
@@ -201,7 +201,7 @@ public class ManifestCmsParserTest {
 
         // Use 10/8 EE cert
         builder.withCertificate(createTenSlashEightResourceCertificate()).withManifestNumber(BigInteger.valueOf(68));
-        builder.withThisUpdateTime(THIS_UPDATE_TIME).withNextUpdateTime(NEXT_UPDATE_TIME);
+        builder.withValidityPeriod(new ValidityPeriod(THIS_UPDATE_TIME, NEXT_UPDATE_TIME));
         builder.addFile("foo1", FOO_CONTENT);
         builder.addFile("BaR", BAR_CONTENT);
 

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/manifest/ManifestCmsTest.java
@@ -225,15 +225,19 @@ public class ManifestCmsTest {
 
         IpResourceSet resources = rootCertificate.getResources();
 
-        CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
+        CertificateRepositoryObjectValidationContext context = new CertificateRepositoryObjectValidationContext(
+                ROOT_CERTIFICATE_LOCATION, rootCertificate, resources, Lists.newArrayList(rootCertificate.getSubject().getName()));
         ValidationResult result = ValidationResult.withLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION);
 
         subject.validateWithCrl(ROOT_SIA_MANIFEST_RSYNC_LOCATION.toASCIIString(), context, ValidationOptions.strictValidation(), result, crl);
 
         assertTrue(result.hasFailures());
         assertEquals(
-                new ValidationCheck(ValidationStatus.ERROR, ValidationString.MANIFEST_THIS_UPDATE_TIME_BEFORE_NEXT_UPDATE_TIME, NEXT_UPDATE_TIME.plusSeconds(1).toString(), NEXT_UPDATE_TIME.toString()),
-                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION), ValidationString.MANIFEST_THIS_UPDATE_TIME_BEFORE_NEXT_UPDATE_TIME)
+                new ValidationCheck(ValidationStatus.ERROR,
+                        ValidationString.MANIFEST_THIS_UPDATE_TIME_BEFORE_NEXT_UPDATE_TIME,
+                        NEXT_UPDATE_TIME.plusSeconds(1).toString(), NEXT_UPDATE_TIME.toString()),
+                result.getResult(new ValidationLocation(ROOT_SIA_MANIFEST_RSYNC_LOCATION),
+                        ValidationString.MANIFEST_THIS_UPDATE_TIME_BEFORE_NEXT_UPDATE_TIME)
         );
     }
 
@@ -455,7 +459,7 @@ public class ManifestCmsTest {
         ManifestCmsBuilder builder = new ManifestCmsBuilder();
         builder.withCertificate(getManifestEEResourceCertificateBuilder().build());
         builder.withManifestNumber(BigInteger.valueOf(68));
-        builder.withThisUpdateTime(validityPeriod.getNotValidBefore()).withNextUpdateTime(validityPeriod.getNotValidAfter());
+        builder.withValidityPeriod(validityPeriod);
         builder.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
         return builder;
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilderTest.java
@@ -159,6 +159,7 @@ public class X509CrlBuilderTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldBeEquivalentToSetDateInDifferentWays() {
         var builder1 = new X509CrlBuilder();
         builder1.withIssuerDN(new X500Principal("CN=ROOT"));

--- a/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/crl/X509CrlBuilderTest.java
@@ -1,5 +1,8 @@
 package net.ripe.rpki.commons.crypto.crl;
 
+import net.ripe.rpki.commons.crypto.ValidityPeriod;
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCmsBuilder;
 import net.ripe.rpki.commons.crypto.util.KeyPairFactoryTest;
 import net.ripe.rpki.commons.crypto.util.KeyPairUtil;
 import net.ripe.rpki.commons.util.UTC;
@@ -19,6 +22,8 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.cert.CRLException;
 
+import static net.ripe.rpki.commons.crypto.cms.manifest.ManifestCmsParserTest.*;
+import static net.ripe.rpki.commons.crypto.cms.manifest.ManifestCmsParserTest.TEST_KEY_PAIR;
 import static net.ripe.rpki.commons.crypto.x509cert.X509CertificateBuilderHelper.*;
 import static org.junit.Assert.*;
 
@@ -151,5 +156,29 @@ public class X509CrlBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void shouldRejectVeryBigCrlNumber() {
         subject.withNumber(BigInteger.valueOf(2).pow(160));
+    }
+
+    @Test
+    public void shouldBeEquivalentToSetDateInDifferentWays() {
+        var builder1 = new X509CrlBuilder();
+        builder1.withIssuerDN(new X500Principal("CN=ROOT"));
+        builder1.withThisUpdateTime(THIS_UPDATE_TIME);
+        builder1.withNextUpdateTime(NEXT_UPDATE_TIME);
+        builder1.withNumber(BigInteger.ONE);
+        builder1.withAuthorityKeyIdentifier(PUBLIC_KEY);
+        builder1.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
+
+        var builder2 = new X509CrlBuilder();
+        builder2.withIssuerDN(new X500Principal("CN=ROOT"));
+        builder2.withValidityPeriod(new ValidityPeriod(THIS_UPDATE_TIME, NEXT_UPDATE_TIME));
+        builder2.withNumber(BigInteger.ONE);
+        builder2.withAuthorityKeyIdentifier(PUBLIC_KEY);
+        builder2.withSignatureProvider(DEFAULT_SIGNATURE_PROVIDER);
+
+        var c1 = builder1.build(PRIVATE_KEY);
+        var c2 = builder2.build(PRIVATE_KEY);
+
+        assertEquals(c1.getThisUpdateTime(), c2.getThisUpdateTime());
+        assertEquals(c1.getNextUpdateTime(), c2.getNextUpdateTime());
     }
 }


### PR DESCRIPTION
  * [x] I have updated the changelog in README.md
  
  This is to avoid mistakes with setting validity dates and getting them backwards (learned the hard way)
