### PR TITLE
Do not encode max length in ROA when it is redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ next (snapshot) release, e.g. `1.1-SNAPSHOT` after releasing `1.0`.
 
 ## Changelog
 
-## 2024-xx-xx
+## 2024-xx-yy 1.37
+  * **fix**: Do not encode redundant maxlength in ROAs
   * Add support for router certificates to the time parsing in `SignedObjectUtil`.
   * Add withValidityPeriod to manifest and CRL builders
   * Add string representation for `RepositoryObjectType`
   * Add `isCmsBased` property on `RepositoryObjectType`.
-  * Add initial step towards Resource Signed Checklist/Trust Anchor Key support, extensions are now recorgnised.
+  * Add initial step towards Resource Signed Checklist/Trust Anchor Key support, extensions are now recognised.
 
 ## 2023-10-31 1.36
   * Access the certificate for the generic signed object parser.

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilder.java
@@ -71,7 +71,7 @@ public class RoaCmsBuilder extends RpkiSignedObjectBuilder {
     ASN1Object encodeRoaIpAddress(RoaPrefix prefix) {
         DERBitString address = Asn1Util.resourceToBitString(prefix.getPrefix().getStart(), prefix.getPrefix().getPrefixLength());
         ASN1Encodable[] encodables;
-        if (prefix.getMaximumLength() == null) {
+        if (prefix.getMaximumLength() == null || prefix.getPrefix().getPrefixLength() == prefix.getMaximumLength()) {
             encodables = new ASN1Encodable[]{address};
         } else {
             encodables = new ASN1Encodable[]{address, new ASN1Integer(prefix.getMaximumLength())};

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilder.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilder.java
@@ -71,7 +71,7 @@ public class RoaCmsBuilder extends RpkiSignedObjectBuilder {
     ASN1Object encodeRoaIpAddress(RoaPrefix prefix) {
         DERBitString address = Asn1Util.resourceToBitString(prefix.getPrefix().getStart(), prefix.getPrefix().getPrefixLength());
         ASN1Encodable[] encodables;
-        if (prefix.getMaximumLength() == null || prefix.getPrefix().getPrefixLength() == prefix.getMaximumLength()) {
+        if (prefix.getPrefix().getPrefixLength() == prefix.getEffectiveMaximumLength()) {
             encodables = new ASN1Encodable[]{address};
         } else {
             encodables = new ASN1Encodable[]{address, new ASN1Integer(prefix.getMaximumLength())};

--- a/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefix.java
+++ b/src/main/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefix.java
@@ -1,21 +1,18 @@
 package net.ripe.rpki.commons.crypto.cms.roa;
 
-import com.google.common.annotations.VisibleForTesting;
-import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import net.ripe.ipresource.IpRange;
-import net.ripe.rpki.commons.util.EqualsSupport;
 import org.apache.commons.lang3.Validate;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.Objects;
 
-@EqualsAndHashCode
+@ToString
 public class RoaPrefix implements Serializable, Comparable<RoaPrefix> {
     private static final Comparator<RoaPrefix> ROA_PREFIX_COMPARATOR = Comparator.comparing(RoaPrefix::getPrefix)
-            .thenComparing(RoaPrefix::getMaximumLength, Comparator.nullsFirst(Comparator.naturalOrder()));
+            .thenComparing(RoaPrefix::getEffectiveMaximumLength, Comparator.nullsFirst(Comparator.naturalOrder()));
     private static final long serialVersionUID = 1L;
 
     private final IpRange prefix;
@@ -47,6 +44,10 @@ public class RoaPrefix implements Serializable, Comparable<RoaPrefix> {
         return prefix;
     }
 
+    /**
+     * Return the maximum length as specified in the structure of the ROA.
+     * <emph>Needed to exactly represent a decoded ROA.</emph> When consuming these objects, use {@link #getEffectiveMaximumLength()} where possible.
+     */
     public Integer getMaximumLength() {
         return maximumLength;
     }
@@ -56,12 +57,19 @@ public class RoaPrefix implements Serializable, Comparable<RoaPrefix> {
     }
 
     @Override
-    public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("prefix", getPrefix()).append("maximumLength", maximumLength).toString();
+    public int compareTo(RoaPrefix o) {
+        return ROA_PREFIX_COMPARATOR.compare(this, o);
+    }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RoaPrefix roaPrefix = (RoaPrefix) o;
+        return Objects.equals(prefix, roaPrefix.prefix) && Objects.equals(getEffectiveMaximumLength(), roaPrefix.getEffectiveMaximumLength());
     }
 
     @Override
-    public int compareTo(RoaPrefix o) {
-        return ROA_PREFIX_COMPARATOR.compare(this, o);
+    public int hashCode() {
+        return Objects.hash(prefix, getEffectiveMaximumLength());
     }
 }

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilderTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaCmsBuilderTest.java
@@ -53,6 +53,16 @@ public class RoaCmsBuilderTest {
     }
 
     @Test
+    public void shouldNotEncodeRedundantMaxLength() {
+        var withRedundantMaxLength = new RoaPrefix(TEST_IPV4_PREFIX_2.getPrefix(), TEST_IPV4_PREFIX_2.getPrefix().getPrefixLength());
+
+        // Ensure base case was already covered
+        assertEncoded(ENCODED_ROA_IP_ADDRESS_2, subject.encodeRoaIpAddress(TEST_IPV4_PREFIX_2));
+        // a redundant maxLength in the prefix should not be encoded -> it should result in the same encoding.
+        assertEncoded(ENCODED_ROA_IP_ADDRESS_2, subject.encodeRoaIpAddress(withRedundantMaxLength));
+    }
+
+    @Test
     public void shouldEncodeRoaIpAddressFamily() {
         assertEncoded(ENCODED_ROA_IP_ADDRESS_FAMILY, subject.encodeRoaIpAddressFamily(AddressFamily.IPV4, Set.copyOf(ipv4Prefixes)));
     }

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
@@ -4,10 +4,7 @@ import com.google.common.collect.Sets;
 import net.ripe.ipresource.IpRange;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.TreeSet;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -61,10 +58,10 @@ public class RoaPrefixTest {
         var p2_8 = new RoaPrefix(IpRange.parse("11.0.0.0/8"), 8);
         var p2_24 = new RoaPrefix(IpRange.parse("11.0.0.0/8"), 24);
 
-        var prefixList = new ArrayList(List.of(p2_24, p1, p2_8, p2));
+        var prefixList = List.of(p2_24, p1, p2_8, p2);
 
         // Static case of re-sorting a list in wrong order
-        var toSort = new ArrayList(List.of(p2_24, p1, p2_8, p2));
+        var toSort = new ArrayList(prefixList);
         Collections.sort(toSort);
         assertThat(toSort).containsExactly(p1, p2, p2_8, p2_24);
 
@@ -73,8 +70,8 @@ public class RoaPrefixTest {
 
         // But test a number of random shuffles as well
         for (int i=0; i < 16; i++) {
-            Collections.shuffle(prefixList);
             toSort = new ArrayList(prefixList);
+            Collections.shuffle(toSort);
             Collections.sort(toSort);
             assertThat(toSort).containsExactly(p1, p2, p2_8, p2_24);
         }

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
@@ -9,28 +9,69 @@ import java.util.List;
 import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class RoaPrefixTest {
     @Test
+    public void shouldEqualWhenSemanticallyEqual() {
+        var s1 = new RoaPrefix(IpRange.parse("10.0.0.0/8"));
+        var s1_null = new RoaPrefix(IpRange.parse("10.0.0.0/8"), null);
+        var s1_8 = new RoaPrefix(IpRange.parse("10.0.0.0/8"), 8);
+
+        var s1_32 = new RoaPrefix(IpRange.parse("10.0.0.0/8"), 32);
+
+        var s2 = new RoaPrefix(IpRange.parse("11.0.0.0/8"));
+        var s2_8 = new RoaPrefix(IpRange.parse("11.0.0.0/8"), 8);
+
+        // not equal when differing prefix or differing maxlength
+        assertThat(s1).isNotEqualTo(s1_32);
+        assertThat(s1).isNotEqualTo(s2);
+        assertThat(s1).isNotEqualTo(s2_8);
+        // or whatever
+        assertThat(s1).isNotEqualTo("🤷‍♂️");
+
+        // reflexive
+        assertThat(s1).isEqualTo(s1);
+        assertThat(s1).isEqualTo(s1_null);
+        assertThat(s1).isEqualTo(s1_8);
+
+        // symmetric
+        assertThat(s1_8).isEqualTo(s1);
+        assertThat(s1_null).isEqualTo(s1);
+
+        // transitive
+        assertThat(s1).isEqualTo(s1_null);
+        assertThat(s1_null).isEqualTo(s1_8);
+        // =>
+        assertThat(s1).isEqualTo(s1_8);
+    }
+
+    @Test
     public void shouldSortRoaPrefixByPrefixThenMaximumLength() {
         var p1 = new RoaPrefix(IpRange.parse("10.0.0.0/8"));
         var p2 = new RoaPrefix(IpRange.parse("11.0.0.0/8"));
+        // An equal copy of p2
         var p2_8 = new RoaPrefix(IpRange.parse("11.0.0.0/8"), 8);
         var p2_24 = new RoaPrefix(IpRange.parse("11.0.0.0/8"), 24);
 
         var prefixList = new ArrayList(List.of(p2_24, p1, p2_8, p2));
 
         // Static case of re-sorting a list in wrong order
-        assertThat(new TreeSet(List.of(p2_24, p1, p2_8, p2)))
-                .containsExactly(p1, p2, p2_8, p2_24);
+        var toSort = new ArrayList(List.of(p2_24, p1, p2_8, p2));
+        Collections.sort(toSort);
+        assertThat(toSort).containsExactly(p1, p2, p2_8, p2_24);
+
+        // **We can not use sets here, because that would deduplicate, i.e p2_8 is gone:
+        assertThat(new TreeSet<>(prefixList)).containsExactly(p1, p2, p2_24);
 
         // But test a number of random shuffles as well
         for (int i=0; i < 16; i++) {
             Collections.shuffle(prefixList);
-            assertThat(new TreeSet(prefixList))
-                    .containsExactly(p1, p2, p2_8, p2_24);
+            toSort = new ArrayList(prefixList);
+            Collections.sort(toSort);
+            assertThat(toSort).containsExactly(p1, p2, p2_8, p2_24);
         }
     }
 
@@ -39,46 +80,35 @@ public class RoaPrefixTest {
     public void shouldEnsureIpAddressIsValidPrefix() {
         new RoaPrefix(IpRange.parse("10.0.0.0/8"), null);
 
-        try {
-            new RoaPrefix(IpRange.parse("10.0.0.0-10.0.2.1"), null);
-            fail("ROA prefix requires legal prefix");
-        } catch (IllegalArgumentException expected) {
-        }
+        assertThatThrownBy(() -> new RoaPrefix(IpRange.parse("10.0.0.0-10.0.2.1"), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .withFailMessage("ROA prefix requires legal prefix");
     }
 
     @Test
     public void shouldEnsureMaximumLengthValidity() {
         new RoaPrefix(IpRange.parse("10.0.0.0/8"), null);
-        try {
-            new RoaPrefix(IpRange.parse("10.0.0.0/8"), -1);
-            fail("maximum length invalid");
-        } catch (IllegalArgumentException expected) {
-        }
+
+        assertThatThrownBy(() -> new RoaPrefix(IpRange.parse("10.0.0.0/8"), -1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .withFailMessage("maximum length invalid");
 
         new RoaPrefix(IpRange.parse("10.0.0.0/8"), 8);
         new RoaPrefix(IpRange.parse("10.0.0.0/8"), 17);
         new RoaPrefix(IpRange.parse("10.0.0.0/8"), 32);
         new RoaPrefix(IpRange.parse("ffe0::/16"), 128);
 
-        try {
-            new RoaPrefix(IpRange.parse("10.0.0.0/8"), 0);
-            fail("maximum length invalid");
-        } catch (IllegalArgumentException expected) {
-        }
-        try {
-            new RoaPrefix(IpRange.parse("10.0.0.0/8"), 7);
-            fail("maximum length invalid");
-        } catch (IllegalArgumentException expected) {
-        }
-        try {
-            new RoaPrefix(IpRange.parse("10.0.0.0/8"), 33);
-            fail("maximum length invalid");
-        } catch (IllegalArgumentException expected) {
-        }
-        try {
-            new RoaPrefix(IpRange.parse("ffe0::/16"), 129);
-            fail("maximum length invalid");
-        } catch (IllegalArgumentException expected) {
-        }
+        assertThatThrownBy(() -> new RoaPrefix(IpRange.parse("10.0.0.0/8"), 0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .withFailMessage("maximum length invalid");
+        assertThatThrownBy(() -> new RoaPrefix(IpRange.parse("10.0.0.0/8"), 7))
+            .isInstanceOf(IllegalArgumentException.class)
+            .withFailMessage("maximum length invalid");
+        assertThatThrownBy(() -> new RoaPrefix(IpRange.parse("10.0.0.0/8"), 33))
+            .isInstanceOf(IllegalArgumentException.class)
+            .withFailMessage("maximum length invalid");
+        assertThatThrownBy(() -> new RoaPrefix(IpRange.parse("ffe0::/16"), 129))
+            .isInstanceOf(IllegalArgumentException.class)
+            .withFailMessage("maximum length invalid");
     }
 }

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
@@ -51,6 +51,20 @@ public class RoaPrefixTest {
     }
 
     @Test
+    public void testCalculateEffectiveLength() {
+        var p2 = new RoaPrefix(IpRange.parse("11.0.0.0/8"));
+        // An equal copy of p2
+        var p2_8 = new RoaPrefix(IpRange.parse("11.0.0.0/8"), 8);
+        var p2_32 = new RoaPrefix(IpRange.parse("11.0.0.0/8"), 32);
+
+        // implict maximum length is the prefix length
+        assertThat(p2.getEffectiveMaximumLength()).isEqualTo(8);
+        assertThat(p2_8.getEffectiveMaximumLength()).isEqualTo(8);
+        // and effective maximum length reflects the actual maximum length
+        assertThat(p2_32.getEffectiveMaximumLength()).isEqualTo(32);
+    }
+
+    @Test
     public void shouldSortRoaPrefixByPrefixThenMaximumLength() {
         var p1 = new RoaPrefix(IpRange.parse("10.0.0.0/8"));
         var p2 = new RoaPrefix(IpRange.parse("11.0.0.0/8"));

--- a/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
+++ b/src/test/java/net/ripe/rpki/commons/crypto/cms/roa/RoaPrefixTest.java
@@ -1,5 +1,6 @@
 package net.ripe.rpki.commons.crypto.cms.roa;
 
+import com.google.common.collect.Sets;
 import net.ripe.ipresource.IpRange;
 import org.junit.Test;
 
@@ -24,6 +25,10 @@ public class RoaPrefixTest {
 
         var s2 = new RoaPrefix(IpRange.parse("11.0.0.0/8"));
         var s2_8 = new RoaPrefix(IpRange.parse("11.0.0.0/8"), 8);
+
+        // hashcode contract
+        assertThat(s1.hashCode()).isEqualTo(s1_null.hashCode());
+        assertThat(s1.hashCode()).isEqualTo(s1_8.hashCode());
 
         // not equal when differing prefix or differing maxlength
         assertThat(s1).isNotEqualTo(s1_32);
@@ -64,7 +69,7 @@ public class RoaPrefixTest {
         assertThat(toSort).containsExactly(p1, p2, p2_8, p2_24);
 
         // **We can not use sets here, because that would deduplicate, i.e p2_8 is gone:
-        assertThat(new TreeSet<>(prefixList)).containsExactly(p1, p2, p2_24);
+        assertThat(new TreeSet<>(prefixList)).hasSize(prefixList.size()-1);
 
         // But test a number of random shuffles as well
         for (int i=0; i < 16; i++) {


### PR DESCRIPTION
Do not encode the max length in a ROA when it is present but redundant.

  * [x] I have updated the changelog in README.md
