### PR TITLE
Use new release plugin, do not sign tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ next (snapshot) release, e.g. `1.1-SNAPSHOT` after releasing `1.0`.
   * Remove the dependency check maven plugin, which was unreliable, now that
     dependabot does the dependency updates.
   * Add and use interfaces for ValidationState logic
+  * Update release plugin, and do not sign tags with release plugin.
 
 ## 2024-02-29 1.38
   * Raise RpkiCaCertificateRequestParserException instead of NPE when an

--- a/pom.xml
+++ b/pom.xml
@@ -432,9 +432,10 @@
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-release-plugin</artifactId>
-                  <version>2.5.3</version>
+                  <version>3.0.1</version>
                   <configuration>
-                    <pushChanges>false</pushChanges>
+                      <pushChanges>false</pushChanges>
+                      <signTag>false</signTag>
                   </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Use a newer release plugin, but do not sign tags. Signing tags prevents using the release plugin on developer laptops.

  * [x] I have updated the changelog in README.md
