### PR TITLE
Release to central.sonatype.org

### DIFF
--- a/ci_settings.xml
+++ b/ci_settings.xml
@@ -11,16 +11,10 @@
     </profiles>
 
     <servers>
-        <!-- public Sonatype repositories for snapshots and staging artifacts to be promoted to the Maven central repo -->
         <server>
-            <id>sonatype-nexus-snapshots</id>
-            <username>${env.SONATYPE_NEXUS_SNAPSHOTS_USERNAME}</username>
-            <password>${env.SONATYPE_NEXUS_SNAPSHOTS_PASSWORD}</password>
-        </server>
-        <server>
-            <id>sonatype-nexus-staging</id>
-            <username>${env.SONATYPE_NEXUS_STAGING_USERNAME}</username>
-            <password>${env.SONATYPE_NEXUS_STAGING_PASSWORD}</password>
+            <id>sonatype-central</id>
+            <username>${env.SONATYPE_CENTRAL_USERNAME}</username>
+            <password>${env.SONATYPE_CENTRAL_PASSWORD}</password>
         </server>
     </servers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <distributionManagement>
-      <snapshotRepository>
-        <id>sonatype-nexus-snapshots</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      </snapshotRepository>
-    </distributionManagement>
-
     <properties>
         <build.number>DEV</build.number>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -354,13 +347,11 @@
             </plugin>
 
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>sonatype-nexus-staging</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <serverId>sonatype-central</serverId>
                 </configuration>
             </plugin>
         </plugins>
@@ -434,9 +425,9 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.7.0</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.8.0</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
oss.sonatype.org has been replaced by central.sonatype.org. Update the publication plugin and credentials.

  * [ ] I have updated the changelog in README.md
