### PR TITLE
central-publishing-maven-plugin: fix server-id link to settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
                 <artifactId>central-publishing-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>sonatype-central</serverId>
+                    <publishingServerId>sonatype-central</publishingServerId>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
  * [x] I have updated the changelog in README.md
